### PR TITLE
Add default command back, version bump to full release

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@agility/cli",
-  "version": "1.0.0-beta.9.17",
+  "version": "1.0.0",
   "description": "Agility CLI for working with your content. (Public Beta)",
   "repository": {
     "type": "git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,9 +28,24 @@ import { initializeLogger, getLogger, finalizeLogger, finalizeAllGuidLoggers } f
 let auth: Auth;
 
 // TODO: Do not hardcode this
-yargs.version("1.0.0-beta.9.0").demand(1).exitProcess(false);
+yargs.exitProcess(false);
 
 console.log(colors.yellow("Welcome to Agility CLI."));
+
+// Default command - shows instructions when no command is provided
+yargs.command({
+  command: "$0",
+  describe: "Default command - shows available commands",
+  handler: function () {
+    console.log(colors.cyan("\nAvailable commands:"));
+    console.log(colors.white("  pull  - Pull your Agility instance locally"));
+    console.log(colors.white("  push  - Push your instance to a target instance"));
+    console.log(colors.white("  sync  - Sync your instance (alias for push with updates enabled)"));
+    console.log(colors.white("\nFor more information, use: --help"));
+    console.log("");
+  },
+});
+
 yargs.command({
   command: "login",
   describe: "Login to Agility.",


### PR DESCRIPTION
https://agilitycms.atlassian.net/browse/PROD-500 - Running CLI with no options give a gross error message
- Added back the default command to the index.ts
- Also fixed a bug with the reported --version on the package

https://agilitycms.atlassian.net/browse/PROD-501 - Version bump to 1.0.0 - full release candidate. 