### PR TITLE
Fix gallery mapper and model pusher issues

### DIFF
--- a/src/lib/mappers/gallery-mapper.ts
+++ b/src/lib/mappers/gallery-mapper.ts
@@ -29,7 +29,6 @@ export class GalleryMapper {
     }
 
     getGalleryMapping(gallery: mgmtApi.assetMediaGrouping, type: 'source' | 'target'): GalleryMapping | null {
-        debugger;
         const mapping = this.mappings.find((m: GalleryMapping) =>
             type === 'source' ? m.sourceMediaGroupingID === gallery.mediaGroupingID : m.targetMediaGroupingID === gallery.mediaGroupingID
         );

--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -47,7 +47,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
 
      // special case for the default RichTextArea model
-    const defaultRichTextArea = model.referenceName === 'RichTextArea' && hasSourceChanged && hasTargetChanged;
+    const defaultRichTextArea = model.referenceName === 'RichTextArea' && !mapping && targetModel;
     if(defaultRichTextArea){
       // force create the mapping for the default RichTextArea model
       referenceMapper.addMapping(model, targetModel);


### PR DESCRIPTION
## Summary
- Remove debugger statement from `gallery-mapper.ts`
- Fix RichTextArea special case logic in `model-pusher.ts`

## Details
- **gallery-mapper.ts**: Removed leftover `debugger;` statement from `getGalleryMapping` method
- **model-pusher.ts**: Corrected the `defaultRichTextArea` condition to check for missing mapping and existing target model instead of checking if both source and target have changed

## Test plan
- [ ] Verify gallery mapping functionality works correctly
- [ ] Verify RichTextArea model synchronization works as expected
- [ ] Ensure no debugger statements remain in production code

🤖 Generated with [Claude Code](https://claude.com/claude-code)