### PR TITLE
PROD-89: Early auth/GUID failure detection

### DIFF
--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -399,6 +399,7 @@ export class Auth {
     // Step 3: Get API keys for all GUIDs
     const allGuids = [...state.sourceGuid, ...state.targetGuid];
     state.apiKeys = [];
+    const failedGuids: string[] = [];
 
     for (const guid of allGuids) {
       if (guid) {
@@ -408,9 +409,21 @@ export class Auth {
 
           state.apiKeys.push({ guid, previewKey, fetchKey });
         } catch (error) {
+          failedGuids.push(guid);
           console.log(ansiColors.yellow(`Warning: Could not get keys for GUID ${guid}: ${error.message}`));
         }
       }
+    }
+
+    // If ALL GUIDs failed key retrieval, this is almost certainly an auth or GUID problem
+    const validGuids = allGuids.filter(g => g);
+    if (validGuids.length > 0 && failedGuids.length === validGuids.length) {
+      console.log(ansiColors.red(`\nError: Failed to retrieve API keys for all specified GUIDs.`));
+      console.log(ansiColors.red(`This usually means either:`));
+      console.log(ansiColors.red(`  1. Your authentication has expired — run 'agility auth' to re-authenticate`));
+      console.log(ansiColors.red(`  2. The GUID(s) are incorrect — verify your --sourceGuid / --targetGuid values`));
+      console.log(ansiColors.red(`  3. Your account does not have access to these instances\n`));
+      return false;
     }
 
     // Step 4: Set up UI mode in state
@@ -524,17 +537,34 @@ export class Auth {
 
 
       } catch (error) {
-        console.log(ansiColors.yellow(`Note: Could not auto-detect locales: ${error.message}`));
-        state.availableLocales = ["en-us"]; // Fallback to default
-
-        // Create fallback mapping for all GUIDs
-        const fallbackLocales = state.locale.length > 0 ? [state.locale[0]] : ["en-us"];
-        for (const guid of allGuids) {
-          if (guid) {
-            state.guidLocaleMap.set(guid, fallbackLocales);
-          }
+        // If we also failed to get keys for any GUIDs, this is likely an auth/GUID problem — fail fast
+        if (failedGuids.length > 0) {
+          console.log(ansiColors.red(`\nError: Unable to retrieve locales, and API key retrieval also failed.`));
+          console.log(ansiColors.red(`This strongly indicates an authentication or GUID configuration problem.`));
+          console.log(ansiColors.red(`  - Run 'agility auth' to re-authenticate`));
+          console.log(ansiColors.red(`  - Verify your --sourceGuid / --targetGuid values are correct\n`));
+          return false;
         }
-        console.log(`📝 Using fallback mapping: all GUIDs → ${fallbackLocales.join(", ")}`);
+
+        // Keys succeeded but locales failed — could be a transient issue, fall back gracefully
+        console.log(ansiColors.yellow(`Warning: Could not auto-detect locales: ${error.message}`));
+        if (state.locale.length > 0) {
+          // User specified locales explicitly, use those
+          const guidLocaleMap = new Map<string, string[]>();
+          for (const guid of allGuids) {
+            if (guid) {
+              guidLocaleMap.set(guid, state.locale);
+            }
+          }
+          state.guidLocaleMap = guidLocaleMap;
+          state.availableLocales = state.locale;
+          console.log(`📝 Using user-specified locales: ${state.locale.join(", ")}`);
+        } else {
+          // No explicit locales and auto-detect failed — can't safely assume en-us
+          console.log(ansiColors.red(`Error: Could not detect available locales and no --locale flag was provided.`));
+          console.log(ansiColors.red(`Please specify locales explicitly with --locale (e.g., --locale en-us)\n`));
+          return false;
+        }
       }
     }
 

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -410,14 +410,13 @@ export class Auth {
           state.apiKeys.push({ guid, previewKey, fetchKey });
         } catch (error) {
           failedGuids.push(guid);
-          console.log(ansiColors.yellow(`Warning: Could not get keys for GUID ${guid}: ${error.message}`));
         }
       }
     }
 
     // If any GUIDs failed key retrieval, this is almost certainly an auth or GUID problem
     if (failedGuids.length > 0) {
-      console.log(ansiColors.red(`\nError: Failed to retrieve API keys for all specified GUIDs.`));
+      console.log(ansiColors.red(`\nError: Failed to retrieve API keys for one or more specified GUIDs.`));
       console.log(ansiColors.red(`This usually means either:`));
       console.log(ansiColors.red(`  1. Your authentication has expired — run 'agility login' to re-authenticate`));
       console.log(ansiColors.red(`  2. The GUID(s) are incorrect — verify your --sourceGuid / --targetGuid values`));
@@ -539,7 +538,7 @@ export class Auth {
         // If we also failed to get keys for any GUIDs, this is likely an auth/GUID problem — fail fast
         // This should never happen, but just in case
         if (failedGuids.length > 0) {
-          console.log(ansiColors.red(`\nError: Unable to retrieve locales, and API key retrieval also failed.`));
+          console.log(ansiColors.red(`Error: Unable to retrieve locales, and API key retrieval also failed.`));
           console.log(ansiColors.red(`This strongly indicates an authentication or GUID configuration problem.`));
           console.log(ansiColors.red(`  - Run 'agility login' to re-authenticate`));
           console.log(ansiColors.red(`  - Verify your --sourceGuid / --targetGuid values are correct\n`));

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -415,9 +415,8 @@ export class Auth {
       }
     }
 
-    // If ALL GUIDs failed key retrieval, this is almost certainly an auth or GUID problem
-    const validGuids = allGuids.filter(g => g);
-    if (validGuids.length > 0 && failedGuids.length === validGuids.length) {
+    // If any GUIDs failed key retrieval, this is almost certainly an auth or GUID problem
+    if (failedGuids.length > 0) {
       console.log(ansiColors.red(`\nError: Failed to retrieve API keys for all specified GUIDs.`));
       console.log(ansiColors.red(`This usually means either:`));
       console.log(ansiColors.red(`  1. Your authentication has expired — run 'agility login' to re-authenticate`));
@@ -538,6 +537,7 @@ export class Auth {
 
       } catch (error) {
         // If we also failed to get keys for any GUIDs, this is likely an auth/GUID problem — fail fast
+        // This should never happen, but just in case
         if (failedGuids.length > 0) {
           console.log(ansiColors.red(`\nError: Unable to retrieve locales, and API key retrieval also failed.`));
           console.log(ansiColors.red(`This strongly indicates an authentication or GUID configuration problem.`));

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -420,7 +420,7 @@ export class Auth {
     if (validGuids.length > 0 && failedGuids.length === validGuids.length) {
       console.log(ansiColors.red(`\nError: Failed to retrieve API keys for all specified GUIDs.`));
       console.log(ansiColors.red(`This usually means either:`));
-      console.log(ansiColors.red(`  1. Your authentication has expired — run 'agility auth' to re-authenticate`));
+      console.log(ansiColors.red(`  1. Your authentication has expired — run 'agility login' to re-authenticate`));
       console.log(ansiColors.red(`  2. The GUID(s) are incorrect — verify your --sourceGuid / --targetGuid values`));
       console.log(ansiColors.red(`  3. Your account does not have access to these instances\n`));
       return false;
@@ -541,7 +541,7 @@ export class Auth {
         if (failedGuids.length > 0) {
           console.log(ansiColors.red(`\nError: Unable to retrieve locales, and API key retrieval also failed.`));
           console.log(ansiColors.red(`This strongly indicates an authentication or GUID configuration problem.`));
-          console.log(ansiColors.red(`  - Run 'agility auth' to re-authenticate`));
+          console.log(ansiColors.red(`  - Run 'agility login' to re-authenticate`));
           console.log(ansiColors.red(`  - Verify your --sourceGuid / --targetGuid values are correct\n`));
           return false;
         }


### PR DESCRIPTION
## Summary
- When all GUIDs fail API key retrieval (e.g. HTTP 500 on `GetPreviewKey`), the CLI now exits immediately with a clear error message instead of continuing
- The locale detection catch block now distinguishes between auth problems (keys also failed → hard error) and transient issues (keys succeeded → graceful handling)
- Removed the silent `en-us` fallback that masked auth failures and caused confusing downstream errors like "Unable to retrieve sitemap"

## Before
```
Warning: Could not get keys for GUID XXX: HTTP 500: Internal Server Error
Warning: Could not get keys for GUID XXX: HTTP 500: Internal Server Error
Note: Could not auto-detect locales: Unable to retrieve locales.
📝 Using fallback mapping: all GUIDs → en-us
Error: Unable to retrieve sitemap.  ← confusing, real problem is auth
```

## After
```
Error: Failed to retrieve API keys for one or more specified GUIDs.
This usually means either:
  1. Your authentication has expired — run 'agility login' to re-authenticate
  2. The GUID(s) are incorrect — verify your --sourceGuid / --targetGuid values
  3. Your account does not have access to these instances
```

## Test plan
- [x] Run a clone/sync command with made-up GUIDs → should get the early auth error
- [x] Run with valid GUIDs and valid auth → should work as before
- [ ] Run with valid GUIDs but expired auth → should get the early auth error
- [ ] Run with `--locale en-us` when locale auto-detect fails (but keys succeed) → should use specified locale
