### PR TITLE
fix: handle spaces and special chars in asset originUrl (PROD-996)

### DIFF
--- a/src/lib/assets/asset-utils.ts
+++ b/src/lib/assets/asset-utils.ts
@@ -14,9 +14,11 @@ export function getAssetFilePath(originUrl: string): string {
 
         let pathname: string;
         try {
-            // Try parsing as a full URL first
-            const url = new URL(originUrl);
-            pathname = url.pathname;
+            // Try parsing as a full URL first, encoding any spaces/special chars that make URL() throw
+            const safeUrl = originUrl.replace(/\s+/g, '%20');
+            const url = new URL(safeUrl);
+            // Decode back so the returned path uses the original filename (with spaces)
+            pathname = decodeURIComponent(url.pathname);
         } catch (e) {
             // If not a full URL, assume it's a path like /instance-name/folder/file.jpg
              if (typeof originUrl === 'string' && originUrl.startsWith('/')) {


### PR DESCRIPTION
## Summary

- Pre-encode spaces in `originUrl` before passing to `new URL()` to prevent a parse error when asset filenames contain spaces

## Changes

`src/lib/assets/asset-utils.ts` — `getAssetFilePath`:
- Replace `new URL(originUrl)` with `new URL(originUrl.replace(/\s+/g, '%20'))` so the URL constructor doesn't throw on filenames with spaces
- Use `decodeURIComponent(url.pathname)` instead of `url.pathname` to restore the human-readable filename after encoding
