### PR TITLE
feat: migrate npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -49,6 +50,4 @@ jobs:
         run: npm run build
 
       - name: Publish
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance


### PR DESCRIPTION
Replaces the NPM_TOKEN secret with GitHub OIDC-based Trusted Publishing. Adds id-token: write permission and --provenance flag, removing the long-lived token that required 90-day rotation.