### PR TITLE
fix: delete orphaned model and container files during pull (PROD-1023, PROD-1027)

### DIFF
--- a/src/lib/downloaders/download-containers.ts
+++ b/src/lib/downloaders/download-containers.ts
@@ -78,6 +78,19 @@ export async function downloadAllContainers(
 
     totalContainers = containers.length;
 
+    // Remove local container files that no longer exist in the source instance
+    const apiContainerIds = new Set(containers.map((c) => c.contentViewID.toString()));
+    if (fs.existsSync(containersFolderPath)) {
+      for (const file of fs.readdirSync(containersFolderPath)) {
+        if (!file.endsWith('.json')) continue;
+        const containerId = file.replace('.json', '');
+        if (!apiContainerIds.has(containerId)) {
+          fs.unlinkSync(path.join(containersFolderPath, file));
+          logger.info(`Removed deleted container file: ${file}`);
+        }
+      }
+    }
+
     if (totalContainers === 0) {
       logger.info("No containers found to download");
       return;

--- a/src/lib/downloaders/download-models.ts
+++ b/src/lib/downloaders/download-models.ts
@@ -67,7 +67,20 @@ export async function downloadAllModels(
 
     const allModels = [...contentModules, ...pageModules];
     totalModels = allModels.length;
-    
+
+    // Remove local model files that no longer exist in the source instance
+    const apiModelIds = new Set(allModels.map((m) => m.id.toString()));
+    if (fs.existsSync(modelsFolderPath)) {
+      for (const file of fs.readdirSync(modelsFolderPath)) {
+        if (!file.endsWith('.json')) continue;
+        const modelId = file.replace('.json', '');
+        if (!apiModelIds.has(modelId)) {
+          fs.unlinkSync(path.join(modelsFolderPath, file));
+          logger.info(`Removed deleted model file: ${file}`);
+        }
+      }
+    }
+
     const downloadableModels = [];
     const skippableModels = [];
 


### PR DESCRIPTION
## Summary
- When a content model or container is deleted from the source instance, the local JSON file was never removed during pull
- Stale files were then pushed to the target instance on the next sync, recreating the deleted content
- Fix adds orphan-cleanup logic in both `download-models.ts` and `download-containers.ts`: after fetching the live list from the API, any local `.json` file whose ID is no longer in the API response is deleted

## Root cause
`downloadAllModels` and `downloadAllContainers` compared API data against disk to skip unchanged files, but never deleted files for items that had been removed from the source entirely. The push path reads everything from disk blindly, so orphaned files were always included.

## Test plan
- [x] Delete a model from a source instance, run sync, confirm the model's JSON file is removed from the local repo
- [x] Delete a container from a source instance, run sync, confirm the container's JSON file is removed
- [x] Confirm deleted model/container does not reappear in the target instance after sync
- [x] Confirm existing (non-deleted) models and containers are unaffected

Fixes PROD-1023, PROD-1027

🤖 Generated with [Claude Code](https://claude.com/claude-code)