### PR TITLE
fix: prevent duplicate content items when target is deleted (PROD-1320)

### DIFF
--- a/src/lib/mappers/content-item-mapper.ts
+++ b/src/lib/mappers/content-item-mapper.ts
@@ -86,6 +86,11 @@ export class ContentItemMapper {
         if (mapping) {
             this.updateMapping(sourceContentItem, targetContentItem);
         } else {
+            // A source contentID can only legitimately map to one target item per locale.
+            // Drop any prior rows for this source — they're stale (e.g. previous target was
+            // deleted and the API just inserted a replacement). Leaving them in would let
+            // .find() return the broken row first and re-trigger the duplicate-create path.
+            this.mappings = this.mappings.filter(m => m.sourceContentID !== sourceContentItem.contentID);
 
             const newMapping: ContentItemMapping = {
                 sourceGuid: this.sourceGuid,
@@ -112,6 +117,14 @@ export class ContentItemMapper {
             mapping.targetContentID = targetContentItem.contentID;
             mapping.sourceVersionID = sourceContentItem.properties.versionID;
             mapping.targetVersionID = targetContentItem.properties.versionID;
+
+            // Drop any other rows for this same source — only one target per source per locale.
+            // Without this, legacy duplicate rows accumulated by past buggy syncs never get
+            // cleaned up because addMapping routes here whenever the new target ID matches an
+            // existing row.
+            this.mappings = this.mappings.filter(m =>
+                m === mapping || m.sourceContentID !== sourceContentItem.contentID
+            );
         }
         this.saveMapping();
     }

--- a/src/lib/pushers/container-pusher.ts
+++ b/src/lib/pushers/container-pusher.ts
@@ -184,7 +184,6 @@ async function updateExistingContainer(
 
   // Update the container
   const updatedContainer = await apiClient.containerMethods.saveContainer(updatePayload, targetGuid, true);
-  logger.container.updated(sourceContainer, "updated", targetGuid)
   return updatedContainer;
 }
 

--- a/src/lib/pushers/content-pusher/content-batch-processor.ts
+++ b/src/lib/pushers/content-pusher/content-batch-processor.ts
@@ -73,7 +73,7 @@ export class ContentBatchProcessor {
 			try {
 				// Prepare content payloads for bulk upload
 
-				const { payloads: contentPayloads, skippedCount: batchSkippedCount, includedItems } = await this.prepareContentPayloads(
+				const { payloads: contentPayloads, skippedCount: batchSkippedCount, includedItems, operationsBySourceId } = await this.prepareContentPayloads(
 					contentBatch,
 					this.config.sourceGuid,
 					this.config.targetGuid
@@ -154,9 +154,12 @@ export class ContentBatchProcessor {
 				// Display individual item results for better visibility
 				if (batchResult.successfulItems.length > 0) {
 					batchResult.successfulItems.forEach((item) => {
-
-						// const modelName = item.originalContent.properties.definitionName || "Unknown";
-						logger.content.created(item.originalContent, `Type: ${batchType} -  created`, this.config.locale, state.targetGuid[0]);
+						const operation = operationsBySourceId.get(item.originalContent?.contentID) ?? "insert";
+						if (operation === "update") {
+							logger.content.updated(item.originalContent, `Type: ${batchType} - updated`, this.config.locale, state.targetGuid[0]);
+						} else {
+							logger.content.created(item.originalContent, `Type: ${batchType} - created`, this.config.locale, state.targetGuid[0]);
+						}
 					});
 				}
 
@@ -255,9 +258,10 @@ export class ContentBatchProcessor {
 		sourceGuid: string,
 		targetGuid: string
 
-	): Promise<{ payloads: any[]; skippedCount: number; includedItems: mgmtApi.ContentItem[] }> {
+	): Promise<{ payloads: any[]; skippedCount: number; includedItems: mgmtApi.ContentItem[]; operationsBySourceId: Map<number, "insert" | "update"> }> {
 		const payloads: any[] = [];
 		const includedItems: mgmtApi.ContentItem[] = [];
+		const operationsBySourceId = new Map<number, "insert" | "update">();
 		let skippedCount = 0;
 
 		// No imports needed - using reference mapper directly
@@ -282,6 +286,7 @@ export class ContentBatchProcessor {
 
 				payloads.push(payload);
 				includedItems.push(contentItem);
+				operationsBySourceId.set(contentItem.contentID, payload.contentID > 0 ? "update" : "insert");
 			} else {
 				//map the content item to the target instance
 				const modelMapping = modelMapper.getModelMappingByReferenceName(contentItem.properties.definitionName, 'source');
@@ -336,10 +341,19 @@ export class ContentBatchProcessor {
 					const existingMapping = this.config.referenceMapper.getContentItemMappingByContentID(contentItem.contentID, 'source');
 					const existingTargetContentItem = this.config.referenceMapper.getMappedEntity(existingMapping, 'target');
 
-					let existingContentID = existingTargetContentItem ? existingTargetContentItem.contentID : -1;
-
-					if (!existingTargetContentItem) {
-						//see if this content item has been mapped in another locale
+					// Resolve target contentID in priority order:
+					//   1. local target file (most authoritative — just pulled)
+					//   2. mapping's targetContentID (target file missing locally but mapping knows the ID;
+					//      send it and let the API tell us if the target was actually deleted — without this
+					//      the payload would default to -1 and INSERT a duplicate on every sync)
+					//   3. cross-locale mapping fallback
+					//   4. -1 (true insert)
+					let existingContentID = -1;
+					if (existingTargetContentItem) {
+						existingContentID = existingTargetContentItem.contentID;
+					} else if (existingMapping?.targetContentID && existingMapping.targetContentID > 0) {
+						existingContentID = existingMapping.targetContentID;
+					} else {
 						existingContentID = await findContentInOtherLocale({
 							sourceGuid,
 							targetGuid,
@@ -415,6 +429,7 @@ export class ContentBatchProcessor {
 
 					payloads.push(payload);
 					includedItems.push(contentItem);
+					operationsBySourceId.set(contentItem.contentID, existingContentID > 0 ? "update" : "insert");
 				} catch (error: any) {
 					console.error(
 						ansiColors.yellow(
@@ -429,7 +444,7 @@ export class ContentBatchProcessor {
 			}
 		}
 
-		return { payloads, skippedCount, includedItems };
+		return { payloads, skippedCount, includedItems, operationsBySourceId };
 	}
 
 	/**


### PR DESCRIPTION
## Summary

Fixes a bug where deleting a content item in the target instance (or running a sync against a partial pull) caused the CLI to silently INSERT a fresh duplicate target item on every subsequent sync. With `--overwrite` this compounded — each run added another duplicate plus a stale mapping row.

- **content-batch-processor.ts** — when the local target file is missing but the mapping knows the target `contentID`, send that ID to `saveContentItems` instead of defaulting to `-1`. The API now either updates the existing target or returns a per-item error if it was truly deleted server-side, instead of silently creating a duplicate.
- **content-item-mapper.ts** — drop any prior rows for the same `sourceContentID` in both `addMapping` and `updateMapping`. Stops legacy stale rows from winning `.find()` lookups on later syncs and accumulating indefinitely.
- **content-batch-processor.ts** — log items as `created` vs `updated` based on whether the payload carried an existing target ID, so the logs reflect what the API actually did.
- **container-pusher.ts** — remove the duplicate `logger.container.updated` call inside `updateExistingContainer` so each container appears once in the log instead of twice. (Cosmetic — only one API call was ever made.)

## Test plan

Verified against dev instances `c01c5f53-d` → `5579cf22-d`:

- [x] Before fix: source `131` mapped to 3 different target IDs (136, 146, 150), accumulated across `--overwrite` runs.
- [x] After fix: rerunning `sync --overwrite` produces zero new mapping rows and zero new duplicate target items.
- [x] `updateMapping` collapses stale rows for the same `sourceContentID` to a single row the next time that source is touched.
- [x] Content log lines now say `updated` for items that already had a mapping, `created` only for genuine inserts.
- [x] Container log lines no longer appear twice.
- [x] Manual: confirm that pre-existing orphaned target items (created by past buggy syncs) are NOT auto-deleted — they need to be cleaned up in the target CMS by hand.

## Notes / follow-ups

- This does not delete orphan target items left over from past buggy syncs (the CLI never deletes target content — that's a destructive op). A separate "prune unmapped target items" command could be a follow-up.
- When multiple stale mapping rows exist for one source, `.find()` still returns the first one. Fix 2 cleans it up on the next successful save, but if that first row points to a target that was actually deleted server-side the customer will now see a real API error instead of a silent duplicate. That's the correct behavior.