### PR TITLE
Rm reference name lookup, use IDs unless source mapping does not exist

### DIFF
--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -52,8 +52,12 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
     }
 
     const sourceMapping = referenceMapper.getModelMappingByID(sourceModel.id, "source");
-    const targetModel =
-      targetData.find((targetModel) => targetModel.referenceName === sourceModel.referenceName) || null;
+
+    let targetModel: mgmtApi.Model = null;
+
+    if(sourceMapping){
+     targetModel = targetData.find((targetModel) => targetModel.id === sourceMapping.targetID ) || null;
+    }
 
     const modelLastModifiedDate = new Date(sourceModel.lastModifiedDate);
     const targetLastModifiedDate = targetModel ? new Date(targetModel.lastModifiedDate) : null;
@@ -68,7 +72,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
     // Handle models that exist in target but have no mapping
     // This ensures downstream containers can find their model mappings
-    const existsInTargetWithoutMapping = !sourceMapping && targetModel;
+    const existsInTargetWithoutMapping = !sourceMapping && targetData.find((targetModel) => targetModel.referenceName === sourceModel.referenceName);
     if (existsInTargetWithoutMapping) {
       const includesDefault = modelDefaults.includes(sourceModel.referenceName.toLowerCase());
 

--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -55,8 +55,8 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
     let targetModel: mgmtApi.Model = null;
 
-    if(sourceMapping){
-     targetModel = targetData.find((targetModel) => targetModel.id === sourceMapping.targetID ) || null;
+    if (sourceMapping) {
+      targetModel = targetData.find((targetModel) => targetModel.id === sourceMapping.targetID) || null;
     }
 
     const modelLastModifiedDate = new Date(sourceModel.lastModifiedDate);
@@ -72,7 +72,10 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
     // Handle models that exist in target but have no mapping
     // This ensures downstream containers can find their model mappings
-    const existsInTargetWithoutMapping = !sourceMapping && !!targetData.find((targetModel) => targetModel.referenceName === sourceModel.referenceName);
+    const targetModelByReference = targetData.find(
+      (targetModel) => targetModel.referenceName === sourceModel.referenceName,
+    );
+    const existsInTargetWithoutMapping = !sourceMapping && targetModelByReference;
     if (existsInTargetWithoutMapping) {
       const includesDefault = modelDefaults.includes(sourceModel.referenceName.toLowerCase());
 
@@ -83,6 +86,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
         shouldSkip.push(sourceModel);
         continue; // Skip remaining conditions - mapping is now created, no further action needed
       } else {
+        targetModel = targetModelByReference;
         const targetMapping = targetModel.id ? referenceMapper.getModelMappingByID(targetModel.id, "target") : null;
         if (targetMapping && targetMapping.sourceID !== sourceModel.id) {
           logger.model.error(

--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -72,7 +72,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
     // Handle models that exist in target but have no mapping
     // This ensures downstream containers can find their model mappings
-    const existsInTargetWithoutMapping = !sourceMapping && targetData.find((targetModel) => targetModel.referenceName === sourceModel.referenceName);
+    const existsInTargetWithoutMapping = !sourceMapping && !!targetData.find((targetModel) => targetModel.referenceName === sourceModel.referenceName);
     if (existsInTargetWithoutMapping) {
       const includesDefault = modelDefaults.includes(sourceModel.referenceName.toLowerCase());
 

--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -81,7 +81,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
       if (includesDefault) {
         // Create the mapping for existing target models (ensures containers can reference them)
-        referenceMapper.addMapping(sourceModel, targetModel);
+        referenceMapper.addMapping(sourceModel, targetModelByReference);
         // Add to skip list since model already exists and is up to date
         shouldSkip.push({ model: sourceModel, reason: "Skipping and adding default Agility mappings." });
         continue; // Skip remaining conditions - mapping is now created, no further action needed


### PR DESCRIPTION
If the source mapping doesnt exist, we check if the target data has a matching ref name, if so, we should throw an error because there is likely renamed model or something. If it is a default model, we protect this on first sync.