### PR TITLE
fix(PROD-1504): surface container and template push failures in error summary

### DIFF
--- a/src/lib/pushers/container-pusher.ts
+++ b/src/lib/pushers/container-pusher.ts
@@ -4,6 +4,7 @@ import { getLoggerForGuid, state } from "core/state";
 import { ContainerMapper } from "lib/mappers/container-mapper";
 import { ModelMapper } from "lib/mappers/model-mapper";
 import { Logs } from "core/logs";
+import { FailureDetail, PusherResult } from "types/sourceData";
 
 /**
  * Container pusher with enhanced version-based comparison
@@ -12,7 +13,7 @@ import { Logs } from "core/logs";
 export async function pushContainers(
   sourceData: mgmtApi.Container[],
   targetData: mgmtApi.Container[],
-): Promise<{ status: "success" | "error"; successful: number; failed: number; skipped: number }> {
+): Promise<PusherResult> {
 
 
   // Extract data from sourceData - unified parameter pattern
@@ -30,6 +31,7 @@ export async function pushContainers(
   let skipped = 0;
   let processedCount = 0;
   let overallStatus: "success" | "error" = "success";
+  const failureDetails: FailureDetail[] = [];
 
   const containerMapper = new ContainerMapper(sourceGuid[0], targetGuid[0]);
   const modelMapper = new ModelMapper(sourceGuid[0], targetGuid[0]);
@@ -140,6 +142,11 @@ export async function pushContainers(
             failed++;
             currentStatus = "error";
             overallStatus = "error";
+            failureDetails.push({
+              name: sourceContainer.referenceName,
+              error: `Failed to update container "${sourceContainer.referenceName}" (ID: ${sourceContainer.contentViewID})`,
+              guid: sourceGuid[0],
+            });
           }
         }
       }
@@ -169,6 +176,11 @@ export async function pushContainers(
             failed++;
             currentStatus = "error";
             overallStatus = "error";
+            failureDetails.push({
+              name: sourceContainer.referenceName,
+              error: `Failed to create container "${sourceContainer.referenceName}"`,
+              guid: sourceGuid[0],
+            });
           }
         }
       }
@@ -177,12 +189,17 @@ export async function pushContainers(
       failed++;
       currentStatus = "error";
       overallStatus = "error";
+      failureDetails.push({
+        name: sourceContainer.referenceName,
+        error: error?.message || String(error),
+        guid: sourceGuid[0],
+      });
     } finally {
       processedCount++;
     }
   }
 
-  return { status: overallStatus, successful, failed, skipped };
+  return { status: overallStatus, successful, failed, skipped, failureDetails };
 }
 
 /**

--- a/src/lib/pushers/template-pusher.ts
+++ b/src/lib/pushers/template-pusher.ts
@@ -5,6 +5,7 @@ import { TemplateMapper } from "lib/mappers/template-mapper";
 import { ModelMapper } from "lib/mappers/model-mapper";
 import { ContainerMapper } from "lib/mappers/container-mapper";
 import { ContentItemMapper } from "lib/mappers/content-item-mapper";
+import { FailureDetail, PusherResult } from "types/sourceData";
 
 
 /**
@@ -17,7 +18,7 @@ export async function pushTemplates(
     targetData: any,
     locale: string
     // onProgress?: (processed: number, total: number, status?: 'success' | 'error') => void
-): Promise<{ status: 'success' | 'error', successful: number, failed: number, skipped: number }> {
+): Promise<PusherResult> {
 
     // Extract data from sourceData - unified parameter pattern
     const templates: mgmtApi.PageModel[] = sourceData || [];
@@ -37,6 +38,7 @@ export async function pushTemplates(
     let processedCount = 0;
     const totalTemplates = templates.length;
     let overallStatus: 'success' | 'error' = 'success';
+    const failureDetails: FailureDetail[] = [];
 
     for (let i = 0; i < templates.length; i++) {
         let template = templates[i];
@@ -126,11 +128,16 @@ export async function pushTemplates(
                 failed++;
                 currentStatus = 'error';
                 overallStatus = 'error';
+                failureDetails.push({
+                    name: template.pageTemplateName,
+                    error: error?.message || String(error),
+                    guid: sourceGuid[0],
+                });
             }
         }
 
         processedCount++;
     }
 
-    return { status: overallStatus, successful, failed, skipped }; // Return status object
+    return { status: overallStatus, successful, failed, skipped, failureDetails };
 }


### PR DESCRIPTION
## Summary

- Container and template push failures were silently dropped from the final ERROR SUMMARY banner
- Added `failureDetails` tracking to `container-pusher.ts` and `template-pusher.ts` so per-item failures now populate the error banner
- Both pushers now return the full `PusherResult` type (including `failureDetails`), matching how the model pusher already worked

## Details

The `pushContainers` and `pushTemplates` functions previously returned an inline object type without a `failureDetails` field. Failures were counted in the `failed` counter but the individual error messages were never collected, so the final ERROR SUMMARY banner had no detail lines for container or template failures.

This fix:
- Imports `FailureDetail` and `PusherResult` from `types/sourceData` in both files
- Initialises a `failureDetails: FailureDetail[]` array at the start of each push loop
- Pushes a `FailureDetail` entry (name, error message, guid) for every failure path (update failure, create failure, and caught exception)
- Returns `{ status, successful, failed, skipped, failureDetails }` so the caller's error summary receives the full detail list

Jira: [PROD-1504]

## Test plan

- [ ] Run a push that includes a container failure and confirm the ERROR SUMMARY banner lists the failing container by name
- [ ] Run a push that includes a template failure and confirm the ERROR SUMMARY banner lists the failing template by name
- [ ] Run a fully successful push and confirm no regressions in the summary output

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-1504]: https://agilitycms.atlassian.net/browse/PROD-1504?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ