### PR TITLE
Fix/PROD-1505 add title field to page zone modules

### DIFF
--- a/src/lib/pushers/page-pusher/process-page.ts
+++ b/src/lib/pushers/page-pusher/process-page.ts
@@ -7,6 +7,7 @@ import { translateZoneNames } from "./translate-zone-names";
 import { findPageInOtherLocale, OtherLocaleMapping } from "./find-page-in-other-locale";
 import { Logs } from "core/logs";
 import { state, getFailedContent, contentExistsInSourceData, contentExistsInOtherLocale } from "core/state";
+import { PageModuleExtended } from "types/sourceData";
 
 interface Props {
 	channel: string,
@@ -76,6 +77,9 @@ export async function processPage({
 
 		// Get channel ID from target instance sitemap (not from existing page which may be invalid)
 		const sitemap = await apiClient.pageMethods.getSitemap(targetGuid, locale);
+		// Get the page from mgmtApi for the module title
+		const mgmtApiPage = await apiClient.pageMethods.getPage(page.pageID, targetGuid, locale);
+
 		//TODO: this is NOT using the channel reference name properly since we don't get that from the mgmt api
 		//TODO: we need to add the channel reference name to the mgmt API for a proper lookup here..
 		const websiteChannel = sitemap?.find((channelObj) => channelObj.name.toLowerCase() === channel.toLowerCase());
@@ -144,7 +148,7 @@ export async function processPage({
 		let sourceZones = page.zones ? { ...page.zones } : {}; // Clone zones or use empty object
 
 		// CRITICAL: Translate zone names to match template expectations BEFORE content mapping
-		let mappedZones = translateZoneNames(sourceZones, targetTemplate);
+		let mappedZones = translateZoneNames(sourceZones, targetTemplate) as { [key: string]: PageModuleExtended[] };
 
 		// Content mapping validation - collect all content IDs that need mapping
 		const contentIdsToValidate: number[] = [];

--- a/src/lib/pushers/page-pusher/process-page.ts
+++ b/src/lib/pushers/page-pusher/process-page.ts
@@ -77,8 +77,6 @@ export async function processPage({
 
 		// Get channel ID from target instance sitemap (not from existing page which may be invalid)
 		const sitemap = await apiClient.pageMethods.getSitemap(targetGuid, locale);
-		// Get the page from mgmtApi for the module title
-		const mgmtApiPage = await apiClient.pageMethods.getPage(page.pageID, targetGuid, locale);
 
 		//TODO: this is NOT using the channel reference name properly since we don't get that from the mgmt api
 		//TODO: we need to add the channel reference name to the mgmt API for a proper lookup here..

--- a/src/types/sourceData.ts
+++ b/src/types/sourceData.ts
@@ -1,5 +1,9 @@
 import * as mgmtApi from "@agility/management-sdk";
 
+export interface PageModuleExtended extends mgmtApi.PageModule {
+    title: string;
+}
+
 /**
  * Standardized source data structure for all pusher operations
  * Replaces 'any' type usage with proper TypeScript interfaces


### PR DESCRIPTION
## Summary

- Adds a `PageModuleExtended` interface in `src/types/sourceData.ts` that extends `mgmtApi.PageModule` with a `title: string` field. This provides a proper, locally-owned type definition rather than patching the upstream SDK.
- In `src/lib/pushers/page-pusher/process-page.ts`, imports `PageModuleExtended` and casts `mappedZones` to `{ [key: string]: PageModuleExtended[] }` immediately after the `translateZoneNames` call. This gives TypeScript-aware access to the `title` field on each zone module so it flows correctly into the page payload sent to `savePage()`.

## Why

The `title` field on page zone modules needs to be included in the payload delivered to `savePage()`, but `mgmtApi.PageModule` does not declare it. The previous workaround was to manually add a `moduleTitle` field directly to the SDK's generated declaration file (`node_modules/@agility/management-sdk/dist/models/pageItem.d.ts`). That approach is fragile — it is wiped on every `npm install` / `yarn install` and is invisible to other contributors.

This change replaces that manual SDK edit with a proper local type extension (`PageModuleExtended`), keeping the fix durable and version-controlled.

## Test plan

- [ ] Run a full page push against a staging instance and confirm zone module titles appear correctly in the target CMS after `savePage()` completes.
- [ ] Verify TypeScript compilation passes with no errors (`tsc --noEmit`).
- [ ] Confirm `node_modules/@agility/management-sdk/dist/models/pageItem.d.ts` no longer requires any manual edits after a clean install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)