### PR TITLE
PROD-2195 / PROD-2196: remove deprecated system args, fix --help, correct README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,29 +27,25 @@ agility pull [options]
 
 **Core Instance Options:**
 
-| Option         | Type   | Default   | Description                                                                                                         |
-| -------------- | ------ | --------- | ------------------------------------------------------------------------------------------------------------------- |
-| `--sourceGuid` | string | _(empty)_ | Source instance GUID (required for sync, can be from .env for pull)                                                 |
-| `--locales`    | string | _(empty)_ | Comma-separated list of locales to operate on. If not specified, locales are automatically pulled from the instance |
+| Option         | Type   | Default   | Description                                                                                                                          |
+| -------------- | ------ | --------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| `--sourceGuid` | string | _(empty)_ | Source instance GUID. **Optional** — falls back to `AGILITY_GUID` from your `.env` file when omitted.                               |
+| `--locales`    | string | _(empty)_ | Comma-separated list of locales to operate on. If not specified, locales are automatically pulled from the instance                 |
+| `--channel`    | string | `website` | Channel (digital channel) to pull sitemaps for. Falls back to `AGILITY_WEBSITE` from your `.env` file.                              |
 
 **Content Selection Options:**
 
-| Option       | Type   | Default                                                      | Description                                                                             |
-| ------------ | ------ | ------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| `--elements` | string | `Models,Galleries,Assets,Containers,Content,Templates,Pages` | Comma-separated list of elements to process                                             |
-| `--models`   | string | _(empty)_                                                    | Comma-separated list of model reference names to sync (only syncs the specified models) |
+| Option       | Type   | Default                                                               | Description                                                                              |
+| ------------ | ------ | -------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `--elements` | string | `Models,Galleries,Assets,Containers,Content,Templates,Pages,Sitemaps` | Comma-separated list of elements to process                                             |
+| `--models`   | string | _(empty)_                                                            | Comma-separated list of model reference names to sync (only syncs the specified models) |
 
-**File System Options:**
+**Authentication & Environment Options:**
 
-| Option       | Type   | Default         | Description                    |
-| ------------ | ------ | --------------- | ------------------------------ |
-| `--rootPath` | string | `agility-files` | Root directory for local files |
-
-**Operation Control Options:**
-
-| Option     | Type    | Default | Description                                 |
-| ---------- | ------- | ------- | ------------------------------------------- |
-| `--update` | boolean | `false` | Set to `true` to force updating source data |
+| Option    | Type    | Default | Description                                                                                                                              |
+| --------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--token` | string  | _(empty)_ | Personal Access Token for headless/CI authentication. Falls back to `AGILITY_TOKEN`. See [PAT Authentication](#personal-access-token-pat-authentication). |
+| `--dev`   | boolean | `false` | Internal/advanced: point the CLI at Agility's development environment instead of production.                                            |
 
 **UI & Output Options:**
 
@@ -67,11 +63,8 @@ agility pull --sourceGuid="abc123"
 # Pull specific elements only
 agility pull --sourceGuid="abc123" --locales="en-us" --elements="Models,Content"
 
-# Pull with update (refresh local files)
-agility pull --sourceGuid="abc123" --locales="en-us" --update=true
-
-# Pull from live environment
-agility pull --sourceGuid="abc123" --locales="en-us"
+# Pull specific locales
+agility pull --sourceGuid="abc123" --locales="en-us,fr-ca"
 ```
 
 ---
@@ -93,28 +86,31 @@ agility sync [options]
 | `--sourceGuid` | string | _(empty)_ | Source instance GUID (required for sync)                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--targetGuid` | string | _(empty)_ | Target instance GUID (required for sync)                                                                                                                                                                                                                                                                                                                                                                                  |
 | `--locales`    | string | _(empty)_ | Comma-separated list of locales to operate on. If not specified, locales are automatically pulled from the source instance. **Note:** For sync operations, if locales are not specified, the target instance must have all the same locales set up, or the sync will error. You can selectively sync only specific locales (e.g., `--locales="en-us"`) to avoid requiring all locales to be set up in the target instance |
+| `--channel`    | string | `website` | Channel (digital channel) whose sitemap is synced. Falls back to `AGILITY_WEBSITE` from your `.env` file.                                                                                                                                                                                                                                                                                                                  |
 
 **Content Selection Options:**
 
-| Option               | Type   | Default                                                      | Description                                                                                                                                         |
-| -------------------- | ------ | ------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--elements`         | string | `Models,Galleries,Assets,Containers,Content,Templates,Pages` | Comma-separated list of elements to process                                                                                                         |
-| `--models`           | string | _(empty)_                                                    | Comma-separated list of model reference names to sync (only syncs the specified models)                                                             |
-| `--models-with-deps` | string | _(empty)_                                                    | Comma-separated list of model reference names to sync with dependencies (includes content, assets, galleries, containers, and lists, but not pages) |
-
-**File System Options:**
-
-| Option       | Type   | Default         | Description                    |
-| ------------ | ------ | --------------- | ------------------------------ |
-| `--rootPath` | string | `agility-files` | Root directory for local files |
+| Option               | Type   | Default                                                               | Description                                                                                                                                                            |
+| -------------------- | ------ | -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `--elements`         | string | `Models,Galleries,Assets,Containers,Content,Templates,Pages,Sitemaps` | Comma-separated list of elements to process                                                                                                                          |
+| `--models`           | string | _(empty)_                                                            | Comma-separated list of model reference names to sync (only syncs the specified models)                                                                              |
+| `--models-with-deps` | string | _(empty)_                                                            | Comma-separated list of model reference names to sync with their full dependency tree — includes dependent content, pages, templates, assets, galleries, and containers |
+| `--contentIDs`       | string | _(empty)_                                                            | Comma-separated list of target content IDs to process directly, bypassing the mappings lookup (e.g. `--contentIDs=121,1221`)                                          |
+| `--pageIDs`          | string | _(empty)_                                                            | Comma-separated list of target page IDs to process directly, bypassing the mappings lookup (e.g. `--pageIDs=12,45`)                                                   |
 
 **Operation Control Options:**
 
 | Option          | Type    | Default      | Description                                                                                                                                                                                                                                           |
 | --------------- | ------- | ------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `--update`      | boolean | `false`      | Download fresh data from source instance before operations, if left false, incremental sync is performed to only get changed data.                                                                                                                    |
-| `--overwrite`   | boolean | `false`      | Force update existing items in target instance instead of creating new items with -1 IDs. Default: false (Warning: may cause duplicate items in lists, overwriting existing content)                                                                  |
+| `--overwrite`   | boolean | `false`      | Conflict-scoped override. By default, when a target item has its own changes that conflict with the source, the CLI skips it to avoid data loss. With `--overwrite`, those conflicting target items are overwritten with the source version. Non-conflicting updates are applied either way. |
 | `--autoPublish` | string  | _(disabled)_ | Automatically publish synced items that were published in the source instance. Values: `content`, `pages`, `both`. If flag is provided without a value, defaults to `both`. Items that are only in staging (not published) in the source are skipped. |
+
+**Authentication & Environment Options:**
+
+| Option    | Type    | Default | Description                                                                                                                              |
+| --------- | ------- | ------- | -------------------------------------------------------------------------------------------------------------------------------------- |
+| `--token` | string  | _(empty)_ | Personal Access Token for headless/CI authentication. Falls back to `AGILITY_TOKEN`. See [PAT Authentication](#personal-access-token-pat-authentication). |
+| `--dev`   | boolean | `false` | Internal/advanced: point the CLI at Agility's development environment instead of production.                                            |
 
 **UI & Output Options:**
 
@@ -135,13 +131,13 @@ agility sync --sourceGuid="abc123" --targetGuid="def456" --locales="en-us"
 # Sync specific elements only
 agility sync --sourceGuid="abc123" --targetGuid="def456" --elements="Assets"
 
-# Force update existing items
+# Overwrite target items that conflict with the source (forces conflicting updates through)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --overwrite
 
 # Sync only specified models (models only, no dependencies)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --models="BlogPost,BlogCategory"
 
-# Sync models with dependencies (includes content, assets, galleries, containers, lists, but not pages)
+# Sync models with their full dependency tree (content, pages, templates, assets, galleries, containers)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --models-with-deps="BlogPost,BlogCategory"
 
 # Sync and auto-publish everything that was published in source
@@ -213,18 +209,17 @@ agility sync --sourceGuid="abc123" --targetGuid="def456" --models="BlogPost,Blog
 
 #### --models-with-deps
 
-The `--models-with-deps` parameter syncs the specified models **plus their dependencies**. It includes:
+The `--models-with-deps` parameter syncs the specified models **plus their full dependency tree**. It includes:
 
 - Content items based on those models
-- Assets referenced by the content
-- Galleries referenced by the content
+- Pages that use those content items or their templates
+- Templates used by those pages
+- Assets referenced by the content and pages
+- Galleries referenced by the content and pages
 - Containers
-- Lists
-
-**Note:** Pages are **not** included when using `--models-with-deps`.
 
 ```bash
-# Sync models with all dependencies (except pages)
+# Sync models with their full dependency tree (content, pages, templates, assets, galleries, containers)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --models-with-deps="BlogPost,BlogCategory"
 ```
 
@@ -234,7 +229,7 @@ agility sync --sourceGuid="abc123" --targetGuid="def456" --models-with-deps="Blo
 # Sync only models (no dependencies)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --models="BlogPost,BlogCategory"
 
-# Sync models with dependencies (content, assets, galleries, containers, lists - but not pages)
+# Sync models with their full dependency tree (content, pages, templates, assets, galleries, containers)
 agility sync --sourceGuid="abc123" --targetGuid="def456" --models-with-deps="Product,ProductCategory,ProductReview"
 ```
 
@@ -342,12 +337,10 @@ For CI/CD pipelines and automation, you can configure the CLI using environment 
 | `AGILITY_WEBSITE`          | `--channel`          | Default channel name                                             |
 | `AGILITY_ELEMENTS`         | `--elements`         | Default elements to process                                      |
 | `AGILITY_MODELS`           | `--models`           | Default models to sync (comma-separated, models only)            |
-| `AGILITY_MODELS_WITH_DEPS` | `--models-with-deps` | Default models to sync with dependencies (comma-separated)       |
-| `AGILITY_ROOT_PATH`        | `--rootPath`         | Default root directory                                           |
 | `AGILITY_VERBOSE`          | `--verbose`          | Default verbose output setting                                   |
 | `AGILITY_HEADLESS`         | `--headless`         | Default headless mode setting                                    |
-| `AGILITY_UPDATE`           | `--update`           | Default fresh data setting (both pull and sync)                  |
 | `AGILITY_OVERWRITE`        | `--overwrite`        | Default overwrite setting (sync only)                            |
+| `AGILITY_DEV`              | `--dev`              | Internal/advanced: target Agility's development environment      |
 | `AGILITY_TOKEN`            | `--token`            | Personal Access Token for headless/CI authentication (see below) |
 
 ### Personal Access Token (PAT) Authentication

--- a/src/core/assets.ts
+++ b/src/core/assets.ts
@@ -14,7 +14,6 @@ export class assets {
     options: mgmtApi.Options,
     multibar: cliProgress.MultiBar,
     fileOps: fileOperations,
-    legacyFolders: boolean = false,
     progressCallback?: (processed: number, total: number, status?: "success" | "error" | "progress") => void
   ) {
     this._options = options;

--- a/src/core/auth.ts
+++ b/src/core/auth.ts
@@ -1,11 +1,10 @@
 import { serverUser } from "../types/serverUser";
-import { state, getState, clearApiClient } from "./state";
+import { state } from "./state";
 import * as mgmtApi from "@agility/management-sdk";
 const open = require("open");
 const FormData = require("form-data");
 import fs from "fs";
 import path from "path";
-import https from "https";
 
 let _keytar: typeof import("keytar") | null | undefined;
 function getKeytar() {
@@ -21,8 +20,6 @@ function getKeytar() {
 import { exit } from "process";
 import ansiColors from "ansi-colors";
 
-import { getAllChannels } from "../lib/shared/get-all-channels";
-
 const SERVICE_NAME = "agility-cli";
 
 let lastLength = 0;
@@ -34,42 +31,6 @@ function logReplace(text) {
 }
 
 export class Auth {
-  private insecureMode: boolean = false;
-
-  constructor(insecureMode: boolean = false) {
-    this.insecureMode = insecureMode;
-  }
-
-  setInsecureMode(insecure: boolean) {
-    this.insecureMode = insecure;
-  }
-
-  private createHttpsAgent() {
-    if (this.insecureMode) {
-      return new https.Agent({
-        rejectUnauthorized: false,
-      });
-    }
-    return undefined;
-  }
-
-  private getFetchConfig(): RequestInit {
-    const config: RequestInit = {
-      headers: {
-        "Cache-Control": "no-cache",
-        "User-Agent": "agility-cli-fetch/1.0",
-      },
-    };
-
-    if (this.insecureMode) {
-      // For fetch with Node.js, we need to handle SSL differently
-      // This is a simplified approach - in production, you might need more sophisticated SSL handling
-      process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-    }
-
-    return config;
-  }
-
   private handleSSLError(error: any): never {
     if (
       error.code === "UNABLE_TO_GET_ISSUER_CERT_LOCALLY" ||
@@ -78,16 +39,12 @@ export class Auth {
     ) {
       console.error("❌ SSL Certificate Error detected.");
       console.error("This often happens in corporate environments with proxy servers.");
-      console.error("Try running with the --insecure flag to bypass SSL verification:");
-      console.error("  npx agility login --insecure");
-      console.error("  npx agility pull --insecure --sourceGuid <your-guid>");
-      console.error("  npx agility sync --insecure --sourceGuid <guid1> --targetGuid <guid2>");
     }
     throw error;
   }
 
-  getEnv(): "dev" | "local" | "preprod" | "prod" {
-    return state.local ? "local" : state.dev ? "dev" : state.preprod ? "preprod" : "prod";
+  getEnv(): "dev" | "prod" {
+    return state.dev ? "dev" : "prod";
   }
 
   checkForEnvFile(): { hasEnvFile: boolean; guid?: string; channel?: string; locales?: string[] } {
@@ -177,18 +134,8 @@ export class Auth {
       baseGUID = state.sourceGuid[0];
     }
 
-    const userBaseUrl = state.baseUrl;
-    if (userBaseUrl) {
-      return userBaseUrl;
-    }
-
-    switch (true) {
-      case state.local:
-        return "https://localhost:5050";
-      case state.dev:
-        return "https://mgmt-dev.aglty.io";
-      case state.preprod:
-        return "https://management-api-us-pre-prod.azurewebsites.net";
+    if (state.dev) {
+      return "https://mgmt-dev.aglty.io";
     }
 
     if (baseGUID) {
@@ -372,8 +319,8 @@ export class Auth {
       redirectUri
     )}&state=cli-code%2e${code}`;
 
-    // Debug logging for local development
-    if (state.local || state.dev) {
+    // Debug logging for dev development
+    if (state.dev) {
       console.log("\n🔍 OAuth Debug Info:");
       console.log(`   Base URL: ${baseUrl}`);
       console.log(`   Redirect URI: ${redirectUri}`);
@@ -390,11 +337,7 @@ export class Auth {
    * Handles everything needed to get the CLI ready for operation
    */
   async init(): Promise<boolean> {
-    // Step 1: Configure SSL if needed
-    const { configureSSL } = await import("./state");
-    configureSSL();
-
-    // Step 2: Authenticate (PAT or Auth0)
+    // Step 1: Authenticate (PAT or Auth0)
     const hasPAT = await this.hasPersonalAccessToken();
     if (hasPAT) {
       console.log(ansiColors.green("🔑 Using Personal Access Token for authentication."));
@@ -441,21 +384,11 @@ export class Auth {
     state.useVerbose = !state.useHeadless && state.verbose;
     // Remove blessed mode - no longer supported
 
-    // Step 5: Check permission bypass flags
-    const shouldSkip = this.shouldSkipPermissionCheck();
-    if (shouldSkip) {
-      if (state.test) {
-        console.log(ansiColors.yellow("🧪 TEST MODE: Bypassing permission checks for analysis..."));
-      } else if (state.test) {
-        console.log(ansiColors.yellow("🧪 TEST MODE: Bypassing permission checks..."));
-      }
-    }
-
     // Step 5: Set up basic management API options
     const mgmtApiOptions = new (await import("@agility/management-sdk")).Options();
     mgmtApiOptions.token = await this.getToken();
 
-    // CRITICAL: Set baseUrl for local/dev/preprod modes BEFORE creating the client
+    // CRITICAL: Resolve the Management API baseUrl BEFORE creating the client
     // This ensures getLocales() and other SDK calls use the correct endpoint
     const baseUrl = this.determineBaseUrl();
     mgmtApiOptions.baseUrl = baseUrl;
@@ -576,8 +509,8 @@ export class Auth {
           console.log(`📝 Using user-specified locales: ${state.locale.join(", ")}`);
         } else {
           // No explicit locales and auto-detect failed — can't safely assume en-us
-          console.log(ansiColors.red(`Error: Could not detect available locales and no --locale flag was provided.`));
-          console.log(ansiColors.red(`Please specify locales explicitly with --locale (e.g., --locale en-us)\n`));
+          console.log(ansiColors.red(`Error: Could not detect available locales and no --locales flag was provided.`));
+          console.log(ansiColors.red(`Please specify locales explicitly with --locales (e.g., --locales en-us)\n`));
           return false;
         }
       }
@@ -1069,7 +1002,7 @@ export class Auth {
         const hasUserLocales = state.locale && state.locale.length > 0;
         const hasAutoDetectedLocales = state.guidLocaleMap && state.guidLocaleMap.size > 0;
         if (!hasUserLocales && !hasAutoDetectedLocales) {
-          missingFields.push("locale (use --locale or AGILITY_LOCALES in .env, or locales will be auto-detected)");
+          missingFields.push("locale (use --locales or AGILITY_LOCALES in .env, or locales will be auto-detected)");
         }
 
         if (!state.channel) missingFields.push("channel (use --channel or AGILITY_WEBSITE in .env)");
@@ -1087,7 +1020,7 @@ export class Auth {
         const hasSyncUserLocales = state.locale && state.locale.length > 0;
         const hasSyncAutoDetectedLocales = state.guidLocaleMap && state.guidLocaleMap.size > 0;
         if (!hasSyncUserLocales && !hasSyncAutoDetectedLocales) {
-          missingFields.push("locale (use --locale or AGILITY_LOCALES in .env, or locales will be auto-detected)");
+          missingFields.push("locale (use --locales or AGILITY_LOCALES in .env, or locales will be auto-detected)");
         }
 
         if (!state.channel) missingFields.push("channel (use --channel or AGILITY_WEBSITE in .env)");
@@ -1112,17 +1045,13 @@ export class Auth {
     }
 
     // Validate instance access and set up API configuration
-    const shouldSkip = this.shouldSkipPermissionCheck();
-
     try {
       if (commandType === "sync" && state.targetGuid && state.targetGuid.length > 0) {
         // Sync operation - validate access to both source and target (use first GUID for validation)
-        if (!shouldSkip) {
-          if (!state.isAgilityDev && !state.dev && !state.local) {
-            await this.validateInstanceAccess(state.sourceGuid[0], "source");
-          }
-          await this.validateInstanceAccess(state.targetGuid[0], "target");
+        if (!state.isAgilityDev && !state.dev) {
+          await this.validateInstanceAccess(state.sourceGuid[0], "source");
         }
+        await this.validateInstanceAccess(state.targetGuid[0], "target");
 
         // Configure for target instance (sync writes to target - use first target GUID)
         const targetBaseUrl = state.baseUrl || this.determineBaseUrl(state.targetGuid[0]);
@@ -1140,16 +1069,14 @@ export class Auth {
         if (!state.apiKeyForPull) {
           console.log(
             ansiColors.red(
-              `Could not retrieve the required API key (preview: ${state.preview}) for source instance ${state.sourceGuid[0]}. Check API key configuration in Agility and --baseUrl if used.`
+              `Could not retrieve the required API key (preview: ${state.preview}) for source instance ${state.sourceGuid[0]}. Check API key configuration in Agility.`
             )
           );
           return false;
         }
       } else if (commandType === "pull" && state.sourceGuid && state.sourceGuid.length > 0) {
         // Pull operation - validate source access and get API keys (use first source GUID for validation)
-        if (!shouldSkip) {
-          await this.validateInstanceAccess(state.sourceGuid[0], "instance");
-        }
+        await this.validateInstanceAccess(state.sourceGuid[0], "instance");
 
         const baseUrl = state.baseUrl || this.determineBaseUrl(state.sourceGuid[0]);
         state.mgmtApiOptions!.baseUrl = baseUrl;
@@ -1166,7 +1093,7 @@ export class Auth {
         if (!state.apiKeyForPull) {
           console.log(
             ansiColors.red(
-              `Could not retrieve the required API key (preview: ${state.preview}) for instance ${state.sourceGuid[0]}. Check API key configuration in Agility and --baseUrl if used.`
+              `Could not retrieve the required API key (preview: ${state.preview}) for instance ${state.sourceGuid[0]}. Check API key configuration in Agility.`
             )
           );
           return false;
@@ -1178,11 +1105,6 @@ export class Auth {
     }
 
     return true;
-  }
-
-  shouldSkipPermissionCheck(): boolean {
-    const state = getState();
-    return state.test;
   }
 
   /**
@@ -1287,7 +1209,7 @@ export class Auth {
 
     if (!apiKeyForPull) {
       throw new Error(
-        `Could not retrieve the required API key (preview: ${isPreview}) for instance ${guid}. Check API key configuration in Agility and --baseUrl if used.`
+        `Could not retrieve the required API key (preview: ${isPreview}) for instance ${guid}. Check API key configuration in Agility.`
       );
     }
 

--- a/src/core/fileOperations.ts
+++ b/src/core/fileOperations.ts
@@ -9,7 +9,6 @@ export class fileOperations {
   private _rootPath: string;
   private _guid: string;
   private _locale: string;
-  private _legacyFolders: boolean;
   private _resolvedRootPath: string;
   private _basePath: string;
   private _instanceLogDir: string;
@@ -22,26 +21,17 @@ export class fileOperations {
     this._guid = guid;
     this._isGuidLevel = locale === undefined || locale === null || locale === "";
     this._locale = locale ?? "";
-    this._legacyFolders = state.legacyFolders;
 
     // Keep paths relative instead of resolving to absolute paths
     // This prevents files from being written to /Users/ directories
     this._resolvedRootPath = state.rootPath;
 
-    // Calculate paths based on legacy mode
-    if (state.legacyFolders) {
-      // Legacy mode: flat structure
-      this._basePath = this._resolvedRootPath;
-      this._mappingsPath = path.join(this._resolvedRootPath, "mappings");
-      this._instanceLogDir = path.join(this._resolvedRootPath, "logs");
-    } else {
-      // Normal mode: nested structure
-      this._basePath = this._isGuidLevel
-        ? path.join(this._resolvedRootPath, this._guid)
-        : path.join(this._resolvedRootPath, this._guid, this._locale);
-      this._mappingsPath = path.join(this._resolvedRootPath, this._guid, "mappings");
-      this._instanceLogDir = path.join(this._basePath, "logs");
-    }
+    // Nested folder structure: rootPath/guid[/locale]
+    this._basePath = this._isGuidLevel
+      ? path.join(this._resolvedRootPath, this._guid)
+      : path.join(this._resolvedRootPath, this._guid, this._locale);
+    this._mappingsPath = path.join(this._resolvedRootPath, this._guid, "mappings");
+    this._instanceLogDir = path.join(this._basePath, "logs");
 
     this._currentLogFilePath = path.join(this._instanceLogDir, "instancelog.txt");
   }
@@ -53,10 +43,6 @@ export class fileOperations {
 
   public get mappingsPath(): string {
     return this._mappingsPath;
-  }
-
-  public get isLegacyMode(): boolean {
-    return this._legacyFolders;
   }
 
   public get resolvedRootPath(): string {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -5,7 +5,7 @@
 
 // Core authentication and state management
 export { Auth } from "./auth";
-export { state, setState, resetState, primeFromEnv, getState, getUIMode, configureSSL } from "./state";
+export { state, setState, resetState, primeFromEnv, getState, getUIMode } from "./state";
 export { systemArgs, type SystemArgsType } from "./system-args";
 export { normalizeProcessArgs, normalizeArgv } from "./arg-normalizer";
 

--- a/src/core/logs.ts
+++ b/src/core/logs.ts
@@ -1021,9 +1021,8 @@ export class Logs {
       Locales: this.guid ? state.guidLocaleMap?.get(this.guid)?.join(", ") || "Not specified" : "Multiple",
       Channel: state.channel || "Not specified",
       Elements: state.elements || "All",
-      "Reset Mode": state.reset ? "Full reset" : "Incremental",
       Verbose: state.verbose ? "Enabled" : "Disabled",
-      "Preview Mode": state.isPreview ? "Preview" : "Live",
+      "Preview Mode": state.preview ? "Preview" : "Live",
     };
 
     const header = generateLogHeader(this.operationType, additionalInfo);

--- a/src/core/pull.ts
+++ b/src/core/pull.ts
@@ -1,8 +1,6 @@
-import * as path from "path";
-import * as fs from "fs";
 import { getState, initializeLogger, finalizeLogger, getLogger } from "./state";
 import ansiColors from "ansi-colors";
-import { markPullStart, clearTimestamps } from "../lib/incremental";
+import { markPullStart } from "../lib/incremental";
 import { waitForFetchApiSync } from "../lib/shared/get-fetch-api-status";
 
 import { Downloader } from "../lib/downloaders/orchestrate-downloaders";
@@ -27,14 +25,10 @@ export class Pull {
     // TODO: Add support for multiple GUIDs, multiple locales, multiple chanels
     // Currently only supports one GUID, one locale, one channel
     // Get all GUIDs to process (both source and target)
-    const { update } = state;
-
     let allGuids = [];
-    if (update === false && fromPush === true) {
-      allGuids = [...state.targetGuid];
-    } else if (update === true && fromPush === true) {
+    if (fromPush === true) {
       allGuids = [...state.sourceGuid, ...state.targetGuid];
-    } else if (update === true && fromPush === false) {
+    } else {
       allGuids = [...state.sourceGuid];
     }
 
@@ -53,13 +47,6 @@ export class Pull {
     }
 
     // operationDetails.forEach((detail) => console.log(`${detail}`));
-
-    // Handle --reset flag: completely delete GUID folders and start fresh
-    if (state.reset) {
-      for (const guid of allGuids) {
-        await this.handleResetFlag(guid);
-      }
-    }
 
     // Mark the start of this pull operation for incremental tracking
     markPullStart();
@@ -124,27 +111,5 @@ export class Pull {
       console.error(ansiColors.red("\n❌ An error occurred during the pull command:"), error);
       throw error; // Let calling code handle error response
     }
-  }
-
-  private async handleResetFlag(guid: string): Promise<void> {
-    const state = getState();
-    const guidFolderPath = path.resolve(state.rootPath, guid);
-
-    if (fs.existsSync(guidFolderPath)) {
-      console.log(ansiColors.red(`🔄 --reset flag detected: Deleting entire instance folder ${guidFolderPath}`));
-
-      try {
-        fs.rmSync(guidFolderPath, { recursive: true, force: true });
-        console.log(ansiColors.green(`✓ Successfully deleted instance folder: ${guidFolderPath}`));
-      } catch (resetError: any) {
-        console.error(ansiColors.red(`✗ Error deleting instance folder: ${resetError.message}`));
-        throw resetError;
-      }
-    } else {
-      console.log(ansiColors.yellow(`⚠️ Instance folder ${guidFolderPath} does not exist (already clean)`));
-    }
-
-    // Clear timestamp tracking for this instance
-    clearTimestamps(guid, state.rootPath);
   }
 }

--- a/src/core/push.ts
+++ b/src/core/push.ts
@@ -1,18 +1,14 @@
-import * as path from "path";
-import * as fs from "fs";
 import {
-  getState,
   initializeLogger,
   finalizeLogger,
   getLogger,
   state,
-  setState,
   clearFailedContentRegistry,
   getPageCmsLink,
   getContentCmsLink,
 } from "./state";
 import ansiColors from "ansi-colors";
-import { markPushStart, clearTimestamps } from "../lib/incremental";
+import { markPushStart } from "../lib/incremental";
 
 import { Pushers, PushResults } from "../lib/pushers/orchestrate-pushers";
 import { Pull } from "./pull";
@@ -74,13 +70,6 @@ export class Push {
       operationDetails.push(`${guid}: ${guidLocales.join(", ")}`);
     }
     // operationDetails.forEach(detail => console.log(`${detail}`));
-
-    // Handle --reset flag: completely delete GUID folders and start fresh
-    if (state.reset) {
-      for (const guid of allGuids) {
-        await this.handleResetFlag(guid);
-      }
-    }
 
     // Mark the start of this pull operation for incremental tracking
     markPushStart();
@@ -445,27 +434,5 @@ export class Push {
 
     // Return errors for display in final summary
     return allErrors;
-  }
-
-  private async handleResetFlag(guid: string): Promise<void> {
-    const state = getState();
-    const guidFolderPath = path.resolve(state.rootPath, guid);
-
-    if (fs.existsSync(guidFolderPath)) {
-      console.log(ansiColors.red(`🔄 --reset flag detected: Deleting entire instance folder ${guidFolderPath}`));
-
-      try {
-        fs.rmSync(guidFolderPath, { recursive: true, force: true });
-        console.log(ansiColors.green(`✓ Successfully deleted instance folder: ${guidFolderPath}`));
-      } catch (resetError: any) {
-        console.error(ansiColors.red(`✗ Error deleting instance folder: ${resetError.message}`));
-        throw resetError;
-      }
-    } else {
-      console.log(ansiColors.yellow(`⚠️ Instance folder ${guidFolderPath} does not exist (already clean)`));
-    }
-
-    // Clear timestamp tracking for this instance
-    clearTimestamps(guid, state.rootPath);
   }
 }

--- a/src/core/state.ts
+++ b/src/core/state.ts
@@ -12,8 +12,6 @@ import { Options } from "@agility/management-sdk";
 export interface State {
   // Environment modes
   dev: boolean;
-  local: boolean;
-  preprod: boolean;
 
   // UI modes
   headless: boolean;
@@ -26,29 +24,20 @@ export interface State {
   availableLocales: string[]; // Detected locales from getLocales() during auth
   guidLocaleMap: Map<string, string[]>; // Per-GUID locale mapping for matrix operations
   channel: string;
-  preview: boolean;
+  preview: boolean; // Always true - operations read from preview environment
   elements: string;
 
   // File system
-  rootPath: string;
-  legacyFolders: boolean;
+  rootPath: string; // Fixed root path for all file operations ("agility-files")
 
   // Network/Security
-  insecure: boolean;
-  baseUrl?: string;
-
-  // Debug/Analysis
-  test: boolean;
+  baseUrl?: string; // Resolved Management API URL (derived, not user-set)
 
   // Operation control
   overwrite: boolean;
-  force: boolean; // New: Override target safety conflicts
-  reset: boolean;
-  update: boolean;
 
   // Workflow operation control
   operationType?: string; // Workflow operation: publish, unpublish, approve, decline, requestApproval
-  dryRun: boolean; // Preview mode - show what would be processed without executing
   autoPublish: string; // Auto-publish after sync: 'content', 'pages', 'both', or '' (disabled)
 
   // Explicit ID overrides (bypass mappings lookup)
@@ -104,8 +93,6 @@ export interface State {
 export const state: State = {
   // Environment modes
   dev: false,
-  local: false,
-  preprod: false,
 
   // UI modes
   headless: false,
@@ -124,21 +111,12 @@ export const state: State = {
 
   // File system
   rootPath: "agility-files",
-  legacyFolders: false,
 
   // Network/Security
-  insecure: false,
   baseUrl: undefined,
-
-  // Debug/Analysis
-  test: false,
 
   // Operation control
   overwrite: false,
-  force: false,
-  reset: false,
-  update: true,
-  dryRun: false,
   autoPublish: "", // Empty string = disabled
 
   // Explicit ID overrides (bypass mappings lookup)
@@ -178,8 +156,6 @@ export const state: State = {
 export function setState(argv: any) {
   // Environment modes
   if (argv.dev !== undefined) state.dev = argv.dev;
-  if (argv.local !== undefined) state.local = argv.local;
-  if (argv.preprod !== undefined) state.preprod = argv.preprod;
 
   // UI modes
   if (argv.headless !== undefined) state.headless = argv.headless;
@@ -213,46 +189,34 @@ export function setState(argv: any) {
   }
 
   // Multi-locale parsing logic
-  if (argv.locale !== undefined) {
-    if (argv.locale.trim() === "") {
+  if (argv.locales !== undefined) {
+    if (argv.locales.trim() === "") {
       // Empty string = auto-detection
       state.locale = [];
-    } else if (argv.locale.includes(",") || argv.locale.includes(" ")) {
+    } else if (argv.locales.includes(",") || argv.locales.includes(" ")) {
       // Multi-locale specification
-      state.locale = argv.locale
+      state.locale = argv.locales
         .split(/[,\s]+/)
         .map((l: string) => l.trim())
         .filter((l: string) => l.length > 0);
     } else {
       // Single locale
-      state.locale = [argv.locale];
+      state.locale = [argv.locales];
     }
   }
 
   if (argv.channel !== undefined) state.channel = argv.channel;
-  if (argv.preview !== undefined) state.preview = argv.preview;
   if (argv.elements !== undefined) state.elements = argv.elements;
 
-  // File system
+  // File system - the --rootPath CLI flag was removed, so this is only set
+  // programmatically (e.g. tests overriding the root for an isolated temp dir).
   if (argv.rootPath !== undefined) state.rootPath = argv.rootPath;
-  if (argv.legacyFolders !== undefined) state.legacyFolders = argv.legacyFolders;
-
-  // Network/Security
-  if (argv.insecure !== undefined) state.insecure = argv.insecure;
-  if (argv.baseUrl !== undefined) state.baseUrl = argv.baseUrl;
-
-  // Debug/Analysis
-  if (argv.test !== undefined) state.test = argv.test;
 
   // Operation control
   if (argv.overwrite !== undefined) state.overwrite = argv.overwrite;
-  if (argv.force !== undefined) state.force = argv.force;
-  if (argv.reset !== undefined) state.reset = argv.reset;
-  if (argv.update !== undefined) state.update = argv.update;
 
   // Workflow operation control
   if (argv.operationType !== undefined) state.operationType = argv.operationType;
-  if (argv.dryRun !== undefined) state.dryRun = argv.dryRun;
   if (argv.autoPublish !== undefined) state.autoPublish = argv.autoPublish;
 
   // Explicit ID overrides - parse comma-separated strings into number arrays
@@ -289,16 +253,6 @@ export function setState(argv: any) {
 }
 
 /**
- * Configure SSL verification based on CLI mode
- */
-export function configureSSL() {
-  if (state.local) {
-    process.env.NODE_TLS_REJECT_UNAUTHORIZED = "0";
-    console.warn("\nWarning: SSL certificate verification is disabled for development/local mode");
-  }
-}
-
-/**
  * Prime state from .env file before setState() is called
  * This allows .env values to be overridden by command line arguments
  */
@@ -320,20 +274,12 @@ export function primeFromEnv(): { hasEnvFile: boolean; primedValues: string[] } 
         AGILITY_TARGET_GUID: envContent.match(uncommentedLine("AGILITY_TARGET_GUID")),
         AGILITY_WEBSITE: envContent.match(uncommentedLine("AGILITY_WEBSITE")),
         AGILITY_LOCALES: envContent.match(uncommentedLine("AGILITY_LOCALES")),
-        AGILITY_TEST: envContent.match(uncommentedLine("AGILITY_TEST")),
         AGILITY_OVERWRITE: envContent.match(uncommentedLine("AGILITY_OVERWRITE")),
 
-        AGILITY_PREVIEW: envContent.match(uncommentedLine("AGILITY_PREVIEW")),
         AGILITY_VERBOSE: envContent.match(uncommentedLine("AGILITY_VERBOSE")),
         AGILITY_HEADLESS: envContent.match(uncommentedLine("AGILITY_HEADLESS")),
         AGILITY_ELEMENTS: envContent.match(uncommentedLine("AGILITY_ELEMENTS")),
-        AGILITY_ROOT_PATH: envContent.match(uncommentedLine("AGILITY_ROOT_PATH")),
-        AGILITY_BASE_URL: envContent.match(uncommentedLine("AGILITY_BASE_URL")),
         AGILITY_DEV: envContent.match(uncommentedLine("AGILITY_DEV")),
-        AGILITY_LOCAL: envContent.match(uncommentedLine("AGILITY_LOCAL")),
-        AGILITY_PREPROD: envContent.match(uncommentedLine("AGILITY_PREPROD")),
-        AGILITY_LEGACY_FOLDERS: envContent.match(uncommentedLine("AGILITY_LEGACY_FOLDERS")),
-        AGILITY_INSECURE: envContent.match(uncommentedLine("AGILITY_INSECURE")),
 
         AGILITY_MODELS: envContent.match(uncommentedLine("AGILITY_MODELS")),
         AGILITY_TOKEN: envContent.match(uncommentedLine("AGILITY_TOKEN")),
@@ -356,19 +302,9 @@ export function primeFromEnv(): { hasEnvFile: boolean; primedValues: string[] } 
       }
 
       // Handle boolean flags - prefer command line args over .env
-      if (envVars.AGILITY_TEST && envVars.AGILITY_TEST[1] && state.test === undefined) {
-        state.test = envVars.AGILITY_TEST[1].trim().toLowerCase() === "true";
-        primedValues.push("test");
-      }
-
       if (envVars.AGILITY_OVERWRITE && envVars.AGILITY_OVERWRITE[1] && state.overwrite === undefined) {
         state.overwrite = envVars.AGILITY_OVERWRITE[1].trim().toLowerCase() === "true";
         primedValues.push("overwrite");
-      }
-
-      if (envVars.AGILITY_PREVIEW && envVars.AGILITY_PREVIEW[1] && state.preview === undefined) {
-        state.preview = envVars.AGILITY_PREVIEW[1].trim().toLowerCase() === "true";
-        primedValues.push("preview");
       }
 
       if (envVars.AGILITY_VERBOSE && envVars.AGILITY_VERBOSE[1] && state.verbose === undefined) {
@@ -386,16 +322,6 @@ export function primeFromEnv(): { hasEnvFile: boolean; primedValues: string[] } 
         primedValues.push("elements");
       }
 
-      if (envVars.AGILITY_ROOT_PATH && envVars.AGILITY_ROOT_PATH[1] && !state.rootPath) {
-        state.rootPath = envVars.AGILITY_ROOT_PATH[1].trim();
-        primedValues.push("rootPath");
-      }
-
-      if (envVars.AGILITY_BASE_URL && envVars.AGILITY_BASE_URL[1] && !state.baseUrl) {
-        state.baseUrl = envVars.AGILITY_BASE_URL[1].trim();
-        primedValues.push("baseUrl");
-      }
-
       // Additional system args
       if (envVars.AGILITY_TARGET_GUID && envVars.AGILITY_TARGET_GUID[1] && state.targetGuid.length === 0) {
         state.targetGuid = [envVars.AGILITY_TARGET_GUID[1].trim()];
@@ -405,26 +331,6 @@ export function primeFromEnv(): { hasEnvFile: boolean; primedValues: string[] } 
       if (envVars.AGILITY_DEV && envVars.AGILITY_DEV[1] && state.dev === undefined) {
         state.dev = envVars.AGILITY_DEV[1].trim().toLowerCase() === "true";
         primedValues.push("dev");
-      }
-
-      if (envVars.AGILITY_LOCAL && envVars.AGILITY_LOCAL[1] && state.local === undefined) {
-        state.local = envVars.AGILITY_LOCAL[1].trim().toLowerCase() === "true";
-        primedValues.push("local");
-      }
-
-      if (envVars.AGILITY_PREPROD && envVars.AGILITY_PREPROD[1] && state.preprod === undefined) {
-        state.preprod = envVars.AGILITY_PREPROD[1].trim().toLowerCase() === "true";
-        primedValues.push("preprod");
-      }
-
-      if (envVars.AGILITY_LEGACY_FOLDERS && envVars.AGILITY_LEGACY_FOLDERS[1] && state.legacyFolders === undefined) {
-        state.legacyFolders = envVars.AGILITY_LEGACY_FOLDERS[1].trim().toLowerCase() === "true";
-        primedValues.push("legacyFolders");
-      }
-
-      if (envVars.AGILITY_INSECURE && envVars.AGILITY_INSECURE[1] && state.insecure === undefined) {
-        state.insecure = envVars.AGILITY_INSECURE[1].trim().toLowerCase() === "true";
-        primedValues.push("insecure");
       }
 
       if (envVars.AGILITY_MODELS && envVars.AGILITY_MODELS[1] && !state.models) {
@@ -465,8 +371,6 @@ export function primeFromEnv(): { hasEnvFile: boolean; primedValues: string[] } 
 export function resetState() {
   // Environment modes
   state.dev = false;
-  state.local = false;
-  state.preprod = false;
 
   // UI modes
   state.headless = false;
@@ -485,24 +389,15 @@ export function resetState() {
 
   // File system
   state.rootPath = "agility-files";
-  state.legacyFolders = false;
 
   // Network/Security
-  state.insecure = false;
   state.baseUrl = undefined;
-
-  // Debug/Analysis
-  state.test = false;
 
   // Operation control
   state.overwrite = false;
-  state.force = false;
-  state.reset = false;
-  state.update = true;
 
   // Workflow operation control
   state.operationType = undefined;
-  state.dryRun = false;
   state.autoPublish = "";
 
   // Explicit ID overrides
@@ -818,7 +713,7 @@ export function clearFailedContentRegistry(): void {
  * - prod: app.agilitycms.com
  */
 export function getCmsAppUrl(): string {
-  if (state.dev || state.local || state.preprod) {
+  if (state.dev) {
     return "https://app-qa.publishwithagility.com";
   }
   return "https://app.agilitycms.com";

--- a/src/core/system-args.ts
+++ b/src/core/system-args.ts
@@ -22,16 +22,6 @@ export const systemArgs = {
     type: "boolean" as const,
     default: false,
   },
-  local: {
-    describe: "Enable local mode",
-    type: "boolean" as const,
-    default: false,
-  },
-  preprod: {
-    describe: "Enable preprod mode",
-    type: "boolean" as const,
-    default: false,
-  },
 
   // UI/Output args
   headless: {
@@ -45,27 +35,13 @@ export const systemArgs = {
     default: true,
   },
 
-  // File system args
-  rootPath: {
-    describe: "Specify the root path for the operation.",
-    demandOption: false,
-    default: "agility-files",
-    type: "string" as const,
-  },
-  legacyFolders: {
-    describe: "Use legacy folder structure (all files in root agility-files folder).",
-    demandOption: false,
-    type: "boolean" as const,
-    default: false,
-  },
-
   // Instance/Connection args
-  locale: {
+  locales: {
     describe:
       "Provide locale(s) for the operation. Comma-separated for multiple locales (e.g., 'en-us,en-ca,fr-fr'). If not provided, all available locales will be auto-detected and used.",
     demandOption: false,
     type: "string" as const,
-    alias: ["locales", "Locales", "LOCALES"],
+    alias: ["Locales", "LOCALES"],
     // No default - auto-detection when not specified
   },
   channel: {
@@ -75,12 +51,6 @@ export const systemArgs = {
     type: "string" as const,
     default: "website",
   },
-  preview: {
-    describe: "Whether to use preview or live environment data.",
-    demandOption: false,
-    type: "boolean" as const,
-    default: true,
-  },
   elements: {
     describe:
       "Comma-separated list of elements to process (Models,Galleries,Assets,Containers,Content,Templates,Pages,Sitemaps)",
@@ -89,23 +59,11 @@ export const systemArgs = {
     default: "Models,Galleries,Assets,Containers,Content,Templates,Pages,Sitemaps",
   },
 
-  // Network/Security args
-  insecure: {
-    describe: "Disable SSL certificate verification",
-    type: "boolean" as const,
-    default: false,
-  },
-  baseUrl: {
-    describe: "(Optional) Specify a base URL for the Agility API, if different from default.",
-    type: "string" as const,
-  },
-
   // **NEW: Selective Model-Based Sync Parameter (Task 103)**
   models: {
     describe:
       "Comma-separated list of model reference names to sync. Filters only specified models and their direct content.",
     demandOption: false,
-    alias: ["model", "Model", "MODEL"],
     type: "string" as const,
     default: "",
   },
@@ -118,23 +76,6 @@ export const systemArgs = {
     alias: ["models-with-deps", "modelswithDeps", "ModelsWithDeps", "MODELSWITHSDEPS"],
     type: "string" as const,
     default: "",
-  },
-
-  // Debug/Analysis args
-  test: {
-    describe:
-      "Enable test mode: bypasses authentication checks for analysis-only operations. Shows detailed analysis and debugging information.",
-    demandOption: false,
-    type: "boolean" as const,
-    default: false,
-  },
-  dryRun: {
-    describe:
-      "Dry run mode: show what items would be processed without executing the operation. Useful for previewing workflow operations.",
-    demandOption: false,
-    type: "boolean" as const,
-    alias: ["dry-run", "dryrun", "DryRun", "DRY_RUN"],
-    default: false,
   },
 
   // **Explicit ID Override for Workflow Operations**
@@ -158,10 +99,9 @@ export const systemArgs = {
   // Instance identification args
   sourceGuid: {
     describe:
-      "Provide the source instance GUID(s). Comma-separated for multiple instances (e.g., 'guid1,guid2,guid3'). If not provided, will use AGILITY_GUID from .env file if available.",
+      "The source Agility instance GUID — the instance you pull from (and the source for a sync). Comma-separated for multiple instances (e.g., 'guid1,guid2,guid3'). Required for pull and sync; falls back to AGILITY_GUID from your .env file when omitted.",
     alias: [
       "source-guid",
-      "sourceGuid",
       "sourceguid",
       "source",
       "SourceGuid",
@@ -178,10 +118,9 @@ export const systemArgs = {
   },
   targetGuid: {
     describe:
-      "Provide the target instance GUID(s) for sync operations. Comma-separated for multiple instances (e.g., 'guid1,guid2,guid3').",
+      "The target Agility instance GUID — the instance you push/sync to. Comma-separated for multiple instances (e.g., 'guid1,guid2,guid3'). Required for sync and push; falls back to AGILITY_TARGET_GUID from your .env file when omitted.",
     alias: [
       "target-guid",
-      "targetGuid",
       "targetguid",
       "target",
       "TargetGuid",
@@ -200,38 +139,18 @@ export const systemArgs = {
   // Force operation args
   overwrite: {
     describe:
-      "For sync commands only: force update existing items in target instance instead of creating new items with -1 IDs. Default: false (safer behavior to prevent overwriting existing content).",
+      "(sync only) Override target safety conflicts. By default, a target item that has its own changes conflicting with the source is skipped to prevent data loss; with --overwrite those conflicting items are overwritten with the source version. Non-conflicting updates are applied either way. Default: false.",
     type: "boolean" as const,
-    alias: ["overwrite", "Overwrite", "OVERWRITE"],
-    default: false,
-  },
-  force: {
-    describe:
-      "Override target safety conflicts during sync operations. When target instance has changes AND change delta has updates, --force will apply sync changes anyway. Default: false (safer behavior to prevent data loss).",
-    type: "boolean" as const,
-    alias: ["force", "Force", "FORCE"],
-    default: false,
-  },
-  update: {
-    describe:
-      "Controls file downloading behavior. --update=false (default): Skip existing files during download (normal efficient behavior). --update=true: Force download/overwrite existing files and clear sync tokens for complete refresh.",
-    type: "boolean" as const,
-    alias: ["reset", "Reset", "RESET", "forceUpdate", "ForceUpdate", "FORCEUPDATE"],
-    default: false,
-  },
-  reset: {
-    describe:
-      "Nuclear reset option: completely delete instance GUID folder including sync tokens. Forces full fresh download for all SDKs. To reset only Content Sync SDK: manually delete agility-files/GUID/locale/preview/state folder. Default: false.",
-    type: "boolean" as const,
+    alias: ["Overwrite", "OVERWRITE"],
     default: false,
   },
 
   // Auto-publish after sync
   autoPublish: {
     describe:
-      "Automatically publish content and/or pages after sync completes. Options: 'content' (publish only content), 'pages' (publish only pages), 'both' (publish content and pages). Default: both when flag is provided.",
+      "(sync only) After the sync completes, automatically publish items that were published in the source instance. Accepts 'content' (content items only), 'pages' (pages only), or 'both'. Providing the flag with no value defaults to 'both'; omit the flag to leave synced items unpublished.",
     demandOption: false,
-    alias: ["auto-publish", "autoPublish", "AutoPublish", "AUTO_PUBLISH", "autopublish"],
+    alias: ["auto-publish", "AutoPublish", "AUTO_PUBLISH", "autopublish"],
     type: "string" as const,
     coerce: (value: string | boolean) => {
       // Handle --autoPublish without value (defaults to 'both')
@@ -258,21 +177,14 @@ export interface SystemArgs {
   clean?: boolean;
   generate?: boolean;
   operationType?: string; // Workflow operation: publish, unpublish, approve, decline, requestApproval
-  test?: boolean;
-  dryRun?: boolean; // Preview mode - show what would be processed without executing
   verbose?: boolean;
   overwrite?: boolean;
-  force?: boolean; // Override target safety conflicts
-  update?: boolean;
-  legacyFolders?: boolean;
   elements?: string;
   guid?: string;
   sourceGuid?: string;
   targetGuid?: string;
-  locale?: string;
+  locales?: string;
   channel?: string;
-  preview?: boolean;
-  rootPath?: string;
   contentIDs?: string; // Explicit content IDs (bypasses mappings)
   pageIDs?: string; // Explicit page IDs (bypasses mappings)
 }

--- a/src/core/tests/assets.test.ts
+++ b/src/core/tests/assets.test.ts
@@ -58,12 +58,6 @@ describe("assets constructor", () => {
     const fileOps = new fileOperations("test-guid", "en-us");
     const multibar = makeMultibarStub();
     const cb = jest.fn();
-    expect(() => new assets({} as any, multibar, fileOps, false, cb)).not.toThrow();
-  });
-
-  it("accepts legacyFolders flag", () => {
-    const fileOps = new fileOperations("test-guid", "en-us");
-    const multibar = makeMultibarStub();
-    expect(() => new assets({} as any, multibar, fileOps, true)).not.toThrow();
+    expect(() => new assets({} as any, multibar, fileOps, cb)).not.toThrow();
   });
 });

--- a/src/core/tests/auth.test.ts
+++ b/src/core/tests/auth.test.ts
@@ -23,28 +23,10 @@ describe("Auth.getEnv", () => {
     expect(auth.getEnv()).toBe("prod");
   });
 
-  it('returns "local" when state.local is true', () => {
-    setState({ local: true });
-    const auth = new Auth();
-    expect(auth.getEnv()).toBe("local");
-  });
-
   it('returns "dev" when state.dev is true', () => {
     setState({ dev: true });
     const auth = new Auth();
     expect(auth.getEnv()).toBe("dev");
-  });
-
-  it('returns "preprod" when state.preprod is true', () => {
-    setState({ preprod: true });
-    const auth = new Auth();
-    expect(auth.getEnv()).toBe("preprod");
-  });
-
-  it("local takes priority over dev", () => {
-    setState({ local: true, dev: true });
-    const auth = new Auth();
-    expect(auth.getEnv()).toBe("local");
   });
 });
 
@@ -95,22 +77,10 @@ describe("Auth.determineBaseUrl", () => {
     expect(auth.determineBaseUrl("my-instance-us2")).toBe("https://mgmt-usa2.aglty.io");
   });
 
-  it("returns localhost when state.local is true", () => {
-    setState({ local: true });
-    const auth = new Auth();
-    expect(auth.determineBaseUrl("any-guid")).toBe("https://localhost:5050");
-  });
-
   it("returns dev URL when state.dev is true", () => {
     setState({ dev: true });
     const auth = new Auth();
     expect(auth.determineBaseUrl("any-guid")).toBe("https://mgmt-dev.aglty.io");
-  });
-
-  it("respects state.baseUrl override", () => {
-    setState({ baseUrl: "https://custom.example.com" });
-    const auth = new Auth();
-    expect(auth.determineBaseUrl("any-guid-u")).toBe("https://custom.example.com");
   });
 
   it("returns default US URL when no GUID is given and no state flags", () => {
@@ -158,12 +128,6 @@ describe("Auth.determineFetchUrl", () => {
     expect(auth.determineFetchUrl("my-guid-us2")).toBe("https://api-usa2.aglty.io");
   });
 
-  it("does NOT switch to localhost even when state.local is true (fetch API is always cloud)", () => {
-    setState({ local: true });
-    const auth = new Auth();
-    expect(auth.determineFetchUrl("my-guid-u")).toBe("https://api.aglty.io");
-  });
-
   it("returns default US fetch URL when no guid provided", () => {
     const auth = new Auth();
     expect(auth.determineFetchUrl()).toBe("https://api.aglty.io");
@@ -195,21 +159,6 @@ describe("Auth.getBaseUrl", () => {
   });
 });
 
-// ─── shouldSkipPermissionCheck ────────────────────────────────────────────────
-
-describe("Auth.shouldSkipPermissionCheck", () => {
-  it("returns false by default", () => {
-    const auth = new Auth();
-    expect(auth.shouldSkipPermissionCheck()).toBe(false);
-  });
-
-  it("returns true when state.test is true", () => {
-    setState({ test: true });
-    const auth = new Auth();
-    expect(auth.shouldSkipPermissionCheck()).toBe(true);
-  });
-});
-
 // ─── generateCode ─────────────────────────────────────────────────────────────
 
 describe("Auth.generateCode", () => {
@@ -226,26 +175,6 @@ describe("Auth.generateCode", () => {
       codes.add(await auth.generateCode());
     }
     expect(codes.size).toBeGreaterThan(1);
-  });
-});
-
-// ─── setInsecureMode ──────────────────────────────────────────────────────────
-
-describe("Auth insecure mode", () => {
-  it("defaults to secure mode", () => {
-    const auth = new Auth();
-    // createHttpsAgent is private, but we can verify the constructor accepts the flag
-    expect(() => new Auth(false)).not.toThrow();
-  });
-
-  it("can be constructed in insecure mode", () => {
-    expect(() => new Auth(true)).not.toThrow();
-  });
-
-  it("setInsecureMode does not throw", () => {
-    const auth = new Auth();
-    expect(() => auth.setInsecureMode(true)).not.toThrow();
-    expect(() => auth.setInsecureMode(false)).not.toThrow();
   });
 });
 

--- a/src/core/tests/fileOperations.test.ts
+++ b/src/core/tests/fileOperations.test.ts
@@ -49,11 +49,6 @@ describe("constructor and path getters", () => {
     expect(ops.guid).toBe("my-guid");
     expect(ops.locale).toBe("en-us");
   });
-
-  it("isLegacyMode is false by default", () => {
-    const ops = new fileOperations("my-guid", "en-us");
-    expect(ops.isLegacyMode).toBe(false);
-  });
 });
 
 // ─── Path utility methods ─────────────────────────────────────────────────────

--- a/src/core/tests/state.test.ts
+++ b/src/core/tests/state.test.ts
@@ -51,24 +51,24 @@ describe("setState – GUID parsing", () => {
   });
 });
 
-describe("setState – locale parsing", () => {
+describe("setState – locale parsing (--locales)", () => {
   it("sets a single locale", () => {
-    setState({ locale: "en-us" });
+    setState({ locales: "en-us" });
     expect(getState().locale).toEqual(["en-us"]);
   });
 
   it("splits comma-separated locales", () => {
-    setState({ locale: "en-us,fr-ca" });
+    setState({ locales: "en-us,fr-ca" });
     expect(getState().locale).toEqual(["en-us", "fr-ca"]);
   });
 
   it("splits space-separated locales", () => {
-    setState({ locale: "en-us fr-ca" });
+    setState({ locales: "en-us fr-ca" });
     expect(getState().locale).toEqual(["en-us", "fr-ca"]);
   });
 
   it("sets empty array for blank locale string", () => {
-    setState({ locale: "  " });
+    setState({ locales: "  " });
     expect(getState().locale).toEqual([]);
   });
 });
@@ -116,24 +116,9 @@ describe("setState – boolean and string flags", () => {
     expect(getState().overwrite).toBe(true);
   });
 
-  it("sets force flag", () => {
-    setState({ force: true });
-    expect(getState().force).toBe(true);
-  });
-
-  it("sets dryRun flag", () => {
-    setState({ dryRun: true });
-    expect(getState().dryRun).toBe(true);
-  });
-
   it("sets autoPublish value", () => {
     setState({ autoPublish: "both" });
     expect(getState().autoPublish).toBe("both");
-  });
-
-  it("sets rootPath", () => {
-    setState({ rootPath: "/custom/path" });
-    expect(getState().rootPath).toBe("/custom/path");
   });
 
   it("sets operationType", () => {
@@ -164,18 +149,15 @@ describe("resetState", () => {
   });
 
   it("resets boolean flags to defaults", () => {
-    setState({ headless: true, verbose: true, overwrite: true, force: true, dryRun: true });
+    setState({ headless: true, verbose: true, overwrite: true });
     resetState();
     const s = getState();
     expect(s.headless).toBe(false);
     expect(s.verbose).toBe(false);
     expect(s.overwrite).toBe(false);
-    expect(s.force).toBe(false);
-    expect(s.dryRun).toBe(false);
   });
 
   it("resets rootPath to agility-files", () => {
-    setState({ rootPath: "/custom" });
     resetState();
     expect(getState().rootPath).toBe("agility-files");
   });
@@ -275,16 +257,6 @@ describe("getCmsAppUrl", () => {
 
   it("returns QA URL when dev=true", () => {
     setState({ dev: true });
-    expect(getCmsAppUrl()).toBe("https://app-qa.publishwithagility.com");
-  });
-
-  it("returns QA URL when local=true", () => {
-    setState({ local: true });
-    expect(getCmsAppUrl()).toBe("https://app-qa.publishwithagility.com");
-  });
-
-  it("returns QA URL when preprod=true", () => {
-    setState({ preprod: true });
     expect(getCmsAppUrl()).toBe("https://app-qa.publishwithagility.com");
   });
 });

--- a/src/core/tests/system-args.test.ts
+++ b/src/core/tests/system-args.test.ts
@@ -6,30 +6,18 @@ describe("systemArgs – required keys exist", () => {
   const expectedKeys = [
     "token",
     "dev",
-    "local",
-    "preprod",
     "headless",
     "verbose",
-    "rootPath",
-    "legacyFolders",
-    "locale",
+    "locales",
     "channel",
-    "preview",
     "elements",
-    "insecure",
-    "baseUrl",
     "models",
     "modelsWithDeps",
-    "test",
-    "dryRun",
     "contentIDs",
     "pageIDs",
     "sourceGuid",
     "targetGuid",
     "overwrite",
-    "force",
-    "update",
-    "reset",
     "autoPublish",
   ];
 
@@ -38,24 +26,31 @@ describe("systemArgs – required keys exist", () => {
   });
 });
 
+describe("systemArgs – removed keys do not exist", () => {
+  const removedKeys = [
+    "local",
+    "preprod",
+    "rootPath",
+    "legacyFolders",
+    "locale",
+    "preview",
+    "insecure",
+    "baseUrl",
+    "test",
+    "dryRun",
+    "force",
+    "update",
+    "reset",
+  ];
+
+  it.each(removedKeys)('no longer exposes "%s"', (key) => {
+    expect(systemArgs).not.toHaveProperty(key);
+  });
+});
+
 describe("systemArgs – types", () => {
   it('boolean args declare type "boolean"', () => {
-    const boolArgs = [
-      "dev",
-      "local",
-      "preprod",
-      "headless",
-      "verbose",
-      "legacyFolders",
-      "preview",
-      "insecure",
-      "test",
-      "dryRun",
-      "overwrite",
-      "force",
-      "update",
-      "reset",
-    ];
+    const boolArgs = ["dev", "headless", "verbose", "overwrite"];
     for (const key of boolArgs) {
       expect((systemArgs as any)[key].type).toBe("boolean");
     }
@@ -64,11 +59,9 @@ describe("systemArgs – types", () => {
   it('string args declare type "string"', () => {
     const strArgs = [
       "token",
-      "rootPath",
-      "locale",
+      "locales",
       "channel",
       "elements",
-      "baseUrl",
       "models",
       "modelsWithDeps",
       "contentIDs",
@@ -83,16 +76,8 @@ describe("systemArgs – types", () => {
 });
 
 describe("systemArgs – defaults", () => {
-  it('rootPath defaults to "agility-files"', () => {
-    expect(systemArgs.rootPath.default).toBe("agility-files");
-  });
-
   it('channel defaults to "website"', () => {
     expect(systemArgs.channel.default).toBe("website");
-  });
-
-  it("preview defaults to true", () => {
-    expect(systemArgs.preview.default).toBe(true);
   });
 
   it("headless defaults to false", () => {
@@ -101,18 +86,6 @@ describe("systemArgs – defaults", () => {
 
   it("overwrite defaults to false", () => {
     expect(systemArgs.overwrite.default).toBe(false);
-  });
-
-  it("force defaults to false", () => {
-    expect(systemArgs.force.default).toBe(false);
-  });
-
-  it("test defaults to false", () => {
-    expect(systemArgs.test.default).toBe(false);
-  });
-
-  it("dryRun defaults to false", () => {
-    expect(systemArgs.dryRun.default).toBe(false);
   });
 
   it("elements includes all expected element types", () => {
@@ -167,20 +140,16 @@ describe("systemArgs.autoPublish coerce", () => {
 // ─── aliases ─────────────────────────────────────────────────────────────────
 
 describe("systemArgs – aliases", () => {
-  it('locale has "locales" alias', () => {
-    expect((systemArgs.locale as any).alias).toContain("locales");
-  });
-
-  it('dryRun has "dry-run" alias', () => {
-    expect((systemArgs.dryRun as any).alias).toContain("dry-run");
+  it('locales has "LOCALES" alias', () => {
+    expect((systemArgs.locales as any).alias).toContain("LOCALES");
   });
 
   it('autoPublish has "auto-publish" alias', () => {
     expect((systemArgs.autoPublish as any).alias).toContain("auto-publish");
   });
 
-  it('models has "model" alias', () => {
-    expect((systemArgs.models as any).alias).toContain("model");
+  it('models no longer has a "model" alias', () => {
+    expect((systemArgs.models as any).alias).toBeUndefined();
   });
 
   it('sourceGuid has "source-guid" alias', () => {
@@ -189,5 +158,26 @@ describe("systemArgs – aliases", () => {
 
   it('targetGuid has "target-guid" alias', () => {
     expect((systemArgs.targetGuid as any).alias).toContain("target-guid");
+  });
+
+  // Regression guard: yargs silently drops an option from `--help` when its
+  // alias array contains the option's own key name. Keep keys out of aliases.
+  it("no option lists its own key name as an alias", () => {
+    for (const [key, def] of Object.entries(systemArgs)) {
+      const alias = (def as any).alias;
+      if (alias) {
+        const aliases = Array.isArray(alias) ? alias : [alias];
+        expect(aliases).not.toContain(key);
+      }
+    }
+  });
+});
+
+describe("systemArgs – help text", () => {
+  it("every option has a non-empty describe (shown in --help)", () => {
+    for (const def of Object.values(systemArgs)) {
+      expect(typeof (def as any).describe).toBe("string");
+      expect((def as any).describe.length).toBeGreaterThan(0);
+    }
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,6 @@ yargs.command({
     }
 
     setState(argv);
-    state.update = true; // Ensure updates are enabled for pull
     state.isPull = true;
 
     auth = new Auth();
@@ -193,9 +192,8 @@ yargs.command({
 
     setState(argv);
 
-    // if the user is "syncing", we need to turn on the updates to the downloaders
+    // mark whether this invocation is a sync or a push
     if (isSync) {
-      state.update = true;
       state.isSync = true;
     } else {
       state.isPush = true;

--- a/src/lib/downloaders/download-assets.ts
+++ b/src/lib/downloaders/download-assets.ts
@@ -8,7 +8,6 @@ import { getAllChannels } from "../shared/get-all-channels";
 
 export async function downloadAllAssets(guid: string): Promise<void> {
   const fileOps = new fileOperations(guid);
-  const update = state.update; // Use state.update instead of parameter
   const apiClient = getApiClient();
   const logger = getLoggerForGuid(guid); // Use GUID-specific logger
 
@@ -42,10 +41,6 @@ export async function downloadAllAssets(guid: string): Promise<void> {
     apiAsset: any,
     localInfo: { dateModified?: string; exists: boolean }
   ): { shouldDownload: boolean; reason: string } {
-    if (state.update === false) {
-      return { shouldDownload: false, reason: "" };
-    }
-
     if (!localInfo.exists) {
       return { shouldDownload: true, reason: "new file" };
     }

--- a/src/lib/downloaders/download-containers.ts
+++ b/src/lib/downloaders/download-containers.ts
@@ -1,5 +1,5 @@
 import { fileOperations } from "../../core/fileOperations";
-import { getApiClient, getLoggerForGuid, getState, state } from "../../core/state";
+import { getApiClient, getLoggerForGuid } from "../../core/state";
 import * as path from "path";
 import ansiColors from "ansi-colors";
 // import { ChangeDelta } from "../shared/change-delta-tracker";
@@ -11,7 +11,6 @@ export async function downloadAllContainers(
   // changeDelta: ChangeDelta
 ): Promise<void> {
   const fileOps = new fileOperations(guid);
-  const update = state.update; // Use state.update instead of parameter
   const apiClient = getApiClient();
   const logger = getLoggerForGuid(guid); // Use GUID-specific logger
 
@@ -51,10 +50,6 @@ export async function downloadAllContainers(
     apiContainer: any,
     localInfo: { lastModifiedDate?: string; exists: boolean }
   ): { shouldDownload: boolean; reason: string } {
-    if (state.update === false) {
-      return { shouldDownload: false, reason: "" };
-    }
-
     if (!localInfo.exists) {
       return { shouldDownload: true, reason: "new file" };
     }
@@ -68,7 +63,7 @@ export async function downloadAllContainers(
     const apiDateTime = parse(apiContainer.lastModifiedDate, "MM/dd/yyyy hh:mma", new Date());
     const localeDateTime = parse(localInfo.lastModifiedDate, "MM/dd/yyyy hh:mma", new Date());
 
-    if (apiDateTime > localeDateTime && state.update === true) {
+    if (apiDateTime > localeDateTime) {
       return { shouldDownload: true, reason: "content changed" };
     }
 

--- a/src/lib/downloaders/download-galleries.ts
+++ b/src/lib/downloaders/download-galleries.ts
@@ -1,12 +1,11 @@
 import { fileOperations } from "../../core/fileOperations";
-import { getApiClient, getLoggerForGuid, getState, state } from "../../core/state";
+import { getApiClient, getLoggerForGuid } from "../../core/state";
 import ansiColors from "ansi-colors";
 import { getAllChannels } from "../shared/get-all-channels";
 import * as mgmtApi from "@agility/management-sdk";
 
 export async function downloadAllGalleries(guid: string): Promise<void> {
   const fileOps = new fileOperations(guid);
-  const update = state.update; // Use state.update instead of parameter
   const apiClient = getApiClient();
   const logger = getLoggerForGuid(guid); // Use GUID-specific logger
 

--- a/src/lib/downloaders/download-models.ts
+++ b/src/lib/downloaders/download-models.ts
@@ -1,5 +1,5 @@
 import { fileOperations } from "core/fileOperations";
-import { getApiClient, getLoggerForGuid, getState, state } from "core/state";
+import { getApiClient, getLoggerForGuid } from "core/state";
 import * as path from "path";
 import * as fs from "fs";
 import { getAllChannels } from "lib/shared/get-all-channels";
@@ -38,10 +38,6 @@ export async function downloadAllModels(guid: string): Promise<void> {
     apiModel: any,
     localInfo: { lastModifiedDate?: string; exists: boolean }
   ): { shouldDownload: boolean; reason: string } {
-    if (state.update === false) {
-      return { shouldDownload: false, reason: "" };
-    }
-
     if (!localInfo.exists) {
       return { shouldDownload: true, reason: "new file" };
     }

--- a/src/lib/downloaders/download-sitemaps.ts
+++ b/src/lib/downloaders/download-sitemaps.ts
@@ -1,5 +1,5 @@
 import { fileOperations } from "../../core/fileOperations";
-import { getApiClient, getLoggerForGuid, getState, state } from "../../core/state";
+import { getApiClient, getLoggerForGuid, state } from "../../core/state";
 import * as fs from "fs";
 import * as path from "path";
 import ansiColors from "ansi-colors";
@@ -8,7 +8,6 @@ import { getAllChannels } from "../shared/get-all-channels";
 export async function downloadAllSitemaps(guid: string): Promise<void> {
   const fileOps = new fileOperations(guid);
   const locales = state.guidLocaleMap.get(guid);
-  const update = state.update;
   const apiClient = getApiClient();
   const logger = getLoggerForGuid(guid); // Use GUID-specific logger
 
@@ -44,7 +43,7 @@ export async function downloadAllSitemaps(guid: string): Promise<void> {
 
     // Check if download is needed (sitemap is an array, so we use the first channel for lastModified check)
     const firstChannel = sitemap[0];
-    const sitemapDownloadDecision = shouldDownloadSitemap(firstChannel, localSitemapInfo, update);
+    const sitemapDownloadDecision = shouldDownloadSitemap(firstChannel, localSitemapInfo);
 
     if (sitemapDownloadDecision.shouldDownload) {
       // Write sitemap file
@@ -84,13 +83,8 @@ function getLocalSitemapInfo(filePath: string): { lastModified?: string; exists:
 
 function shouldDownloadSitemap(
   channel: any,
-  localSitemapInfo: { lastModified?: string; exists: boolean },
-  forceUpdate: boolean = false
+  localSitemapInfo: { lastModified?: string; exists: boolean }
 ): { shouldDownload: boolean; reason: string } {
-  if (state.update === false) {
-    return { shouldDownload: false, reason: "" };
-  }
-
   if (!localSitemapInfo.exists) {
     return { shouldDownload: true, reason: "local file does not exist" };
   }

--- a/src/lib/downloaders/download-sync-sdk.ts
+++ b/src/lib/downloaders/download-sync-sdk.ts
@@ -34,12 +34,11 @@ export async function downloadSyncSDKByLocaleAndChannel(guid: string, channel: s
   const instanceSpecificPath = fileOps.getDataFolderPath();
   const syncTokenPath = fileOps.getDataFilePath("state", "sync.json");
 
-  const isIncrementalSync = await handleSyncToken(syncTokenPath, state.reset);
+  const isIncrementalSync = await handleSyncToken(syncTokenPath, false);
 
   const logger = getLoggerForGuid(guid);
   // Configure the Agility Sync client
   // NOTE: Use determineFetchUrl (not determineBaseUrl) because:
-  // - Management API uses localhost:5050 when --local is set
   // - Content Fetch/Sync API is always cloud-based (based on GUID suffix)
   // The baseUrl must include the GUID path segment for the SDK to construct correct URLs:
   // e.g., https://api-dev.aglty.io/{guid} → https://api-dev.aglty.io/{guid}/preview/{locale}/sync/items

--- a/src/lib/downloaders/orchestrate-downloaders.ts
+++ b/src/lib/downloaders/orchestrate-downloaders.ts
@@ -1,4 +1,3 @@
-import ansiColors from "ansi-colors";
 import { DownloadOperationsRegistry } from "./download-operations-config";
 import { getState, initializeGuidLogger, finalizeGuidLogger } from "core/state";
 
@@ -94,24 +93,6 @@ export class Downloader {
 
     if (allGuids.length === 0) {
       throw new Error("No GUIDs available for download operation");
-    }
-
-    // Use sequential mode when running against local API to prevent crashes
-    // Local debugging sessions can't handle as many concurrent requests
-    if (state.local) {
-      console.log(ansiColors.gray("Using sequential download mode for local API..."));
-      const successfulResults: DownloadResults[] = [];
-
-      for (const guid of allGuids) {
-        try {
-          const result = await this.guidDownloader(guid, fromPush);
-          successfulResults.push(result);
-        } catch (error: any) {
-          console.error(`Failed download: ${guid} - ${error?.message || "Unknown error"}`);
-        }
-      }
-
-      return successfulResults;
     }
 
     // Start ALL downloads simultaneously (true parallel execution) for cloud APIs

--- a/src/lib/getters/filesystem/get-containers-from-list.ts
+++ b/src/lib/getters/filesystem/get-containers-from-list.ts
@@ -11,17 +11,10 @@ export function getContainersFromFileSystem(
   guid: string,
   locale: string,
   isPreview: boolean,
-  rootPath?: string,
-  legacyFolders?: boolean
+  rootPath?: string
 ): mgmtApi.Container[] {
   const baseFolder = rootPath || "agility-files";
-  let listPath: string;
-
-  if (legacyFolders) {
-    listPath = `${baseFolder}/list`;
-  } else {
-    listPath = `${baseFolder}/${guid}/${locale}/${isPreview ? "preview" : "live"}/list`;
-  }
+  const listPath = `${baseFolder}/${guid}/${locale}/${isPreview ? "preview" : "live"}/list`;
 
   if (!fs.existsSync(listPath)) {
     console.warn(`[Containers] List directory not found: ${listPath}`);
@@ -32,9 +25,7 @@ export function getContainersFromFileSystem(
   const containers: mgmtApi.Container[] = [];
 
   // Also load models to resolve definitionName to model ID (like chain-data-loader does)
-  const modelsPath = legacyFolders
-    ? `${baseFolder}/models`
-    : `${baseFolder}/${guid}/${locale}/${isPreview ? "preview" : "live"}/models`;
+  const modelsPath = `${baseFolder}/${guid}/${locale}/${isPreview ? "preview" : "live"}/models`;
 
   const models = loadModels(modelsPath);
 

--- a/src/lib/getters/filesystem/tests/get-containers-from-list.test.ts
+++ b/src/lib/getters/filesystem/tests/get-containers-from-list.test.ts
@@ -197,33 +197,6 @@ describe("getContainersFromFileSystem (from-list)", () => {
     });
   });
 
-  describe("legacy folder mode", () => {
-    it("reads list from flat baseFolder/list path when legacyFolders is true", () => {
-      const root = path.join(tmpDir, "legacy-list");
-      const lp = path.join(root, "list");
-      fs.mkdirSync(lp, { recursive: true });
-
-      const contentList = [
-        { contentID: 1, properties: { referenceName: "legacyRef", definitionName: "LegacyModel", state: 1 } },
-      ];
-      fs.writeFileSync(path.join(lp, "legacyRef.json"), JSON.stringify(contentList));
-
-      const result = getContainersFromFileSystem("g-010", "en-us", false, root, true);
-
-      expect(result).toHaveLength(1);
-      expect((result[0] as any).referenceName).toBe("legacyRef");
-    });
-
-    it("returns empty array when legacy list directory does not exist", () => {
-      const root = path.join(tmpDir, "legacy-list-missing");
-      fs.mkdirSync(root, { recursive: true });
-
-      const result = getContainersFromFileSystem("g-011", "en-us", false, root, true);
-
-      expect(result).toEqual([]);
-    });
-  });
-
   describe("preview vs live mode", () => {
     it("reads from preview sub-directory when isPreview is true", () => {
       const root = path.join(tmpDir, "preview-mode");

--- a/src/lib/pushers/asset-pusher.ts
+++ b/src/lib/pushers/asset-pusher.ts
@@ -244,7 +244,6 @@ async function createAsset(
     },
     maxContentLength: Infinity,
     maxBodyLength: Infinity,
-    httpsAgent: state.local ? new (require("https").Agent)({ rejectUnauthorized: false }) : undefined,
   });
 
   const uploadedMediaArray = response.data as mgmtApi.Media[];
@@ -329,7 +328,6 @@ async function updateAsset(
     },
     maxContentLength: Infinity,
     maxBodyLength: Infinity,
-    httpsAgent: state.local ? new (require("https").Agent)({ rejectUnauthorized: false }) : undefined,
   });
 
   const uploadedMediaArray = response.data as mgmtApi.Media[];

--- a/src/lib/workflows/tests/workflow-operation.test.ts
+++ b/src/lib/workflows/tests/workflow-operation.test.ts
@@ -101,32 +101,6 @@ describe("WorkflowOperation.executeFromMappings", () => {
     });
   });
 
-  describe("dry run mode", () => {
-    it("returns without calling workflowOrchestrator when dryRun=true", async () => {
-      state.sourceGuid = ["src-u"];
-      state.targetGuid = ["tgt-u"];
-      state.locale = ["en-us"];
-      state.dryRun = true;
-      state.operationType = "unpublish";
-
-      jest.spyOn(mappingReader, "getMappingSummary").mockReturnValue(makeMappingSummary(3, 2));
-      jest
-        .spyOn(mappingReader, "readMappingsForGuidPair")
-        .mockReturnValue(makeMappingResult({ contentIds: [1, 2, 3], pageIds: [10, 11] }));
-
-      const orchestratorSpy = jest.spyOn(workflowOrchestratorModule, "workflowOrchestrator");
-
-      const op = new WorkflowOperation();
-      const result = await op.executeFromMappings();
-
-      expect(orchestratorSpy).not.toHaveBeenCalled();
-      expect(result.success).toBe(true);
-      // dry run reports would-be counts
-      expect(result.contentProcessed).toBe(3);
-      expect(result.pagesProcessed).toBe(2);
-    });
-  });
-
   describe("publish operation with source status check", () => {
     it("filters content to only published-in-source IDs", async () => {
       state.sourceGuid = ["src-u"];

--- a/src/lib/workflows/workflow-operation.ts
+++ b/src/lib/workflows/workflow-operation.ts
@@ -260,43 +260,6 @@ export class WorkflowOperation {
       console.log(ansiColors.gray(`Content items to ${operationName}: ${contentIds.length}`));
       console.log(ansiColors.gray(`Pages to ${operationName}: ${pageIds.length}`));
 
-      // DRY RUN: Show preview and exit without executing
-      if (state.dryRun) {
-        console.log(ansiColors.yellow("\n" + "═".repeat(50)));
-        console.log(ansiColors.yellow(`🔍 DRY RUN PREVIEW - ${operationName.toUpperCase()}`));
-        console.log(ansiColors.yellow("═".repeat(50)));
-        console.log(ansiColors.gray("\nThe following items would be processed:"));
-
-        if (contentIds.length > 0) {
-          console.log(ansiColors.cyan(`\n📄 Content Items (${contentIds.length}):`));
-          const displayContentIds = contentIds.slice(0, 20);
-          displayContentIds.forEach((id) => console.log(ansiColors.white(`    • ID: ${id}`)));
-          if (contentIds.length > 20) {
-            console.log(ansiColors.gray(`    ... and ${contentIds.length - 20} more content items`));
-          }
-        }
-
-        if (pageIds.length > 0) {
-          console.log(ansiColors.cyan(`\n📑 Pages (${pageIds.length}):`));
-          const displayPageIds = pageIds.slice(0, 20);
-          displayPageIds.forEach((id) => console.log(ansiColors.white(`    • ID: ${id}`)));
-          if (pageIds.length > 20) {
-            console.log(ansiColors.gray(`    ... and ${pageIds.length - 20} more pages`));
-          }
-        }
-
-        console.log(ansiColors.yellow("\n" + "─".repeat(50)));
-        console.log(ansiColors.yellow("⚠️  DRY RUN COMPLETE - No changes were made"));
-        console.log(ansiColors.gray(`Remove --dryRun flag to execute the ${operationName} operation`));
-        console.log(ansiColors.yellow("─".repeat(50)));
-
-        result.contentProcessed = contentIds.length;
-        result.pagesProcessed = pageIds.length;
-        result.elapsedTime = Date.now() - startTime;
-        finalizeLogger();
-        return result;
-      }
-
       // Execute workflow operation
       console.log(ansiColors.cyan("\n" + "─".repeat(50)));
       console.log(ansiColors.cyan(`🚀 ${operationName.toUpperCase()} PHASE (${modeDescription})`));

--- a/src/types/syncAnalysis.ts
+++ b/src/types/syncAnalysis.ts
@@ -20,7 +20,6 @@ export interface SyncAnalysisContext {
   locale: string;
   isPreview: boolean;
   rootPath: string;
-  legacyFolders?: boolean;
   debug: boolean;
   elements: string[];
   modelTracker?: ModelTracker; // Optional model tracking for duplicate detection


### PR DESCRIPTION
Supersedes #162 (which was based on the now-outdated `PROD-2195-2196` branch — it documented flags that this PR removes).

## PROD-2195 — system-args cleanup

Removed the following CLI flags and collapsed their code paths:
`--rootPath`, `--insecure`, `--legacyFolders`, `--local`, `--preprod`, `--locale` (kept `--locales`), `--preview`, `--baseURL`, `--model` (kept `--models`), `--test`, `--dryRun`, `--force`, `--update`/`--forceUpdate`, `--reset`.

- Pure feature-gate flags (insecure/SSL, reset, dryRun, test mode, legacy folders, local/preprod env modes) had their branches removed entirely.
- Per decision: downloaders now **always re-download** (`state.update` removed).
- `state.rootPath` / `state.baseUrl` / `state.preview` kept as fixed internal values the code still needs (the user-facing flags are gone).
- **Fixed a real `--help` bug:** `--sourceGuid`, `--targetGuid`, `--overwrite`, `--autoPublish` were silently hidden from `--help` because each listed its own key name as an alias. Removed the self-referential aliases and expanded their help text.
- Updated affected unit tests; added regression tests guarding against self-aliases and missing `describe`.

## PROD-2196 — README accuracy (reconciled with the removals above)

- `--overwrite` documented as **conflict-scoped** (verified against the pushers).
- `--models-with-deps` documented as **including pages + templates** (verified against the dependency-tree builder).
- pull `--sourceGuid` marked **optional** with `AGILITY_GUID` fallback.
- Documented the surviving previously-missing flags (`--channel`, `--token`, `--dev`, `--contentIDs`, `--pageIDs`); did **not** re-add removed flags.
- `--elements` default now includes `Sitemaps`.
- Env-var table corrected: removed `AGILITY_MODELS_WITH_DEPS` (never primed by the code) and added `AGILITY_DEV`.

## Verification
- `tsc` build clean.
- Full unit-test suite passes (run per-file): 1,659 tests green.
- `agility pull/sync --help` now renders all four previously-hidden flags with accurate descriptions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)