### PR TITLE
fix(PROD-2277): models-only sync crashes in push with ENOENT on galleries folder

### DIFF
--- a/src/core/fileOperations.ts
+++ b/src/core/fileOperations.ts
@@ -271,6 +271,14 @@ export class fileOperations {
   }
 
   getFolderContents(folder: string) {
+    // A scoped run (e.g. a models-only sync) legitimately skips downloading some
+    // element types, so their instance subfolder is never created. Create the
+    // folder on demand and return an empty listing instead of throwing ENOENT,
+    // matching how readJsonFilesFromFolder/listFilesInFolder already degrade.
+    if (!fs.existsSync(folder)) {
+      fs.mkdirSync(folder, { recursive: true });
+      return [];
+    }
     return fs.readdirSync(folder);
   }
 

--- a/src/core/tests/fileOperations.test.ts
+++ b/src/core/tests/fileOperations.test.ts
@@ -251,6 +251,31 @@ describe("listFilesInFolder", () => {
   });
 });
 
+// ─── getFolderContents ────────────────────────────────────────────────────────
+
+describe("getFolderContents", () => {
+  it("lists the entries of an existing folder", () => {
+    const dir = path.join(tmpDir, "fc-guid", "galleries");
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, "1.json"), "{}");
+    fs.writeFileSync(path.join(dir, "2.json"), "{}");
+
+    const ops = new fileOperations("fc-guid");
+    expect(ops.getFolderContents(dir).sort()).toEqual(["1.json", "2.json"]);
+  });
+
+  it("creates the folder and returns [] when it does not exist (models-only sync regression)", () => {
+    const dir = path.join(tmpDir, "fc-missing-guid", "galleries");
+    expect(fs.existsSync(dir)).toBe(false);
+
+    const ops = new fileOperations("fc-missing-guid");
+    expect(ops.getFolderContents(dir)).toEqual([]);
+    // The folder is created on demand so a scoped run that skipped downloading
+    // galleries does not crash later in the push pipeline with ENOENT.
+    expect(fs.existsSync(dir)).toBe(true);
+  });
+});
+
 // ─── saveMappingFile / getMappingFile ─────────────────────────────────────────
 
 describe("saveMappingFile / getMappingFile", () => {

--- a/src/lib/getters/filesystem/tests/get-galleries.test.ts
+++ b/src/lib/getters/filesystem/tests/get-galleries.test.ts
@@ -34,10 +34,20 @@ function makeFileOps(subDir: string): fileOperations {
 }
 
 describe("getGalleriesFromFileSystem", () => {
-  it("throws or returns empty when galleries folder does not exist", () => {
+  it("returns empty and creates the folder when galleries folder does not exist", () => {
     const fileOps = makeFileOps("galleries-missing");
-    // getFolderContents (readdirSync) throws when directory does not exist
-    expect(() => getGalleriesFromFileSystem(fileOps)).toThrow();
+    const galleriesDir = path.join(fileOps.instancePath, "galleries");
+    expect(fs.existsSync(galleriesDir)).toBe(false);
+
+    // A models-only sync skips downloading galleries, so the folder is absent.
+    // getFolderContents creates it on demand and returns [] instead of throwing
+    // ENOENT, which previously crashed the push phase (PROD-2277).
+    let result: any;
+    expect(() => {
+      result = getGalleriesFromFileSystem(fileOps);
+    }).not.toThrow();
+    expect(result).toEqual([]);
+    expect(fs.existsSync(galleriesDir)).toBe(true);
   });
 
   it("returns an empty array when galleries folder is empty", () => {


### PR DESCRIPTION
## Summary

A models-only sync — `sync --models="X"` (and the same code path for `--elements="Models"`) — crashes in the **push** phase on a clean machine:

```
✗ Sync completed with errors
  •  sync: guid-orchestration: ENOENT: no such file or directory,
     scandir 'agility-files/<sourceGuid>/galleries'
```

This is a regression from **PROD-2215** (#166). That fix correctly makes a models-only scope download *only* model definitions (skipping assets, galleries, content) — but the push-side loader still reads the galleries folder unconditionally, and that folder is now never created.

## Root cause

- `guid-data-loader.ts` (~L85, ~L400) calls `getGalleriesFromFileSystem()` unconditionally during push.
- → `get-galleries.ts` → `fileOperations.getFolderContents()` → `fs.readdirSync(folder)` with **no existence guard** (`fileOperations.ts` ~L273).
- Pre-PROD-2215 the downloader fetched galleries regardless of scope, which created `agility-files/<guid>/galleries` (even empty), so `readdirSync` returned `[]`. PROD-2215 stopped creating it for models-only runs → `ENOENT`.

## Fix

`getFolderContents` now creates the folder on demand and returns `[]` when absent, matching the guards already in `readJsonFilesFromFolder`/`listFilesInFolder`:

```ts
getFolderContents(folder: string) {
  if (!fs.existsSync(folder)) {
    fs.mkdirSync(folder, { recursive: true });
    return [];
  }
  return fs.readdirSync(folder);
}
```

Creating the folder (rather than only guarding the read) also restores the consistent instance-folder scaffolding downstream steps assume. All four callers (get-galleries, gallery-mapper, mapping-reader ×2) want "list files, empty if none", so auto-create is safe.

## Testing

- Clean `sync --sourceGuid=… --targetGuid=… --models="AssetTest"` (no local `agility-files`, no workaround) → `✓ Sync completed successfully`; galleries/assets correctly skipped in push; folders auto-created.
- Regression test added in `fileOperations.test.ts` (missing folder → returns `[]` **and** folder is created).
- Affected suites green (fileOperations / gallery-pusher / gallery-mapper / mapping-reader); full suite 1685 tests passing.

Jira: PROD-2277

🤖 Generated with [Claude Code](https://claude.com/claude-code)