### PR TITLE
PROD-1033: expand .npmignore to match .gitignore hygiene

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,3 +1,57 @@
+# Only the compiled dist/ (plus README, LICENSE, package.json) should ship.
+# .npmignore takes precedence over .gitignore, so this must be kept in sync
+# with .gitignore to keep non-runtime files out of the published package.
+
+# --- Source (dist/ is what runs, per "main": "dist/index.js") ---
 /src/
+
+# --- Agility working directories (created at runtime by the CLI/tests) ---
 /.agility-files/
 /agility-files/
+**/agility-files/
+
+# --- Dependencies / build output that isn't published ---
+/node_modules
+/.pnp
+.pnp.js
+/build
+/temp/
+
+# --- Environment files ---
+.env
+.env.*
+
+# --- Test artifacts & config ---
+/coverage
+*.test.ts
+*.integration.test.ts
+jest.config.js
+tsconfig.test.json
+
+# --- Build / TypeScript config (not needed at runtime) ---
+tsconfig.json
+tsconfig*.json
+*.map
+
+# --- Lint / format config ---
+eslint.config.js
+.prettierrc
+.prettierignore
+
+# --- CI / repo tooling ---
+.github/
+.claude/
+.vscode/
+.cursor/
+*.workspace
+/.cert
+code.json
+structure.txt
+changelog.md
+
+# --- OS / editor / log junk ---
+.DS_Store
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*


### PR DESCRIPTION
## Summary

The published `@agility/cli` npm package was shipping a lot of non-runtime files. Because `.npmignore` takes precedence over `.gitignore` when present, the previous thin `.npmignore` (which only excluded `/src/`, `/.agility-files/`, `/agility-files/`) meant files excluded from git still made it into the tarball.

Before this change, `npm pack --dry-run` included: `.github/`, `.claude/`, `.vscode/`, `.prettierrc`, `.prettierignore`, `eslint.config.js`, `jest.config.js`, `tsconfig.json`, `tsconfig.test.json`, `changelog.md`, and `structure.txt`.

This PR expands `.npmignore` to cover all non-runtime files (dev configs, env files, test artifacts/config, TypeScript/build config, lint/format config, CI/repo tooling, and OS/editor junk), organized to mirror `.gitignore` hygiene.

## Verification

`npm pack --dry-run` (after a clean `npm run build`) now ships **only**:

- `dist/` (compiled output + `.d.ts` type definitions — what `main`/`bin` point at)
- `README.md`
- `license.txt`
- `package.json`

## Acceptance criteria

- [x] `.npmignore` covers all non-runtime files
- [x] `npm pack --dry-run` output reviewed — only runtime files ship

Ticket: https://agilitycms.atlassian.net/browse/PROD-1033

🤖 Generated with [Claude Code](https://claude.com/claude-code)