### PR TITLE
PROD-2250: process already-mapped source models before new ones on push

### DIFF
--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -83,7 +83,24 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
   let shouldSkip: { model: mgmtApi.Model; reason: string }[] = [];
   let stubCreated = [];
 
+  // PROD-2250: process source models that already have a mapping before brand-new
+  // (unmapped) models. Reconciling existing target models first — using their known
+  // mapping — avoids ordering issues where a net-new model is created before its
+  // already-mapped dependencies have been reconciled, and keeps the mappings file
+  // consistent. Each group preserves its original relative order; the mapper is
+  // already loaded so the membership check is O(1). A clean run (empty mappings)
+  // yields an empty existingMappedModels, so ordering/output is unchanged.
+  const existingMappedModels: mgmtApi.Model[] = [];
+  const newUnmappedModels: mgmtApi.Model[] = [];
   for (const sourceModel of models) {
+    const isAlreadyMapped = sourceModel.id
+      ? !!referenceMapper.getModelMappingByID(sourceModel.id, "source")
+      : false;
+    (isAlreadyMapped ? existingMappedModels : newUnmappedModels).push(sourceModel);
+  }
+  const orderedModels = [...existingMappedModels, ...newUnmappedModels];
+
+  for (const sourceModel of orderedModels) {
     if (!sourceModel.id || !sourceModel.referenceName) {
       logger.model.error(
         sourceModel,

--- a/src/lib/pushers/tests/model-pusher.test.ts
+++ b/src/lib/pushers/tests/model-pusher.test.ts
@@ -356,3 +356,126 @@ describe("pushModels — exists in target without mapping, non-default (PROD-221
     expect(result.skipped).toBe(0);
   });
 });
+
+// ─── PROD-2250: mapped-before-unmapped model processing order ────────────────
+
+describe("pushModels — mapped-before-unmapped ordering (PROD-2250)", () => {
+  // Spies on ModelMapper#getModelMappingByID so we can observe the ORDER source
+  // models are walked through the main categorization loop, without depending
+  // on which downstream branch (create/update/skip) each model takes.
+  function spyOnSourceMappingLookupOrder(ModelMapperClass: any): number[] {
+    const callOrder: number[] = [];
+    const original = ModelMapperClass.prototype.getModelMappingByID;
+    jest.spyOn(ModelMapperClass.prototype, "getModelMappingByID").mockImplementation(function (
+      this: any,
+      id: number,
+      type: "source" | "target"
+    ) {
+      if (type === "source") callOrder.push(id);
+      return original.call(this, id, type);
+    });
+    return callOrder;
+  }
+
+  // Unique target IDs per saveModel call avoid mapping-row collisions — both
+  // within a single run and across the tests in this describe block, since the
+  // mapping file persists on disk for the shared source/target GUID pair until
+  // afterAll removes tmpDir. Counter is shared (not reset per test) on purpose.
+  let uniqueTargetIdCounter = 90000;
+  function makeUniqueSaveModel() {
+    return jest
+      .fn()
+      .mockImplementation(async (payload: any) =>
+        makeModel({ id: ++uniqueTargetIdCounter, referenceName: payload.referenceName })
+      );
+  }
+
+  it("processes already-mapped source models before brand-new unmapped ones", async () => {
+    const { ModelMapper } = await import("lib/mappers/model-mapper");
+
+    const fixedDateB = new Date(2024, 0, 1).toISOString();
+    const fixedDateD = new Date(2024, 5, 1).toISOString();
+
+    const seeder = new ModelMapper(state.sourceGuid[0], state.targetGuid[0]);
+    const sourceB = makeModel({ id: 102, referenceName: "ModelB-Mapped", lastModifiedDate: fixedDateB });
+    const targetB = makeModel({ id: 1020, referenceName: "ModelB-Mapped", lastModifiedDate: fixedDateB });
+    seeder.addMapping(sourceB, targetB);
+    const sourceD = makeModel({ id: 104, referenceName: "ModelD-Mapped", lastModifiedDate: fixedDateD });
+    const targetD = makeModel({ id: 1040, referenceName: "ModelD-Mapped", lastModifiedDate: fixedDateD });
+    seeder.addMapping(sourceD, targetD);
+
+    const modelA = makeModel({ id: 101, referenceName: "ModelA-Unmapped" });
+    const modelC = makeModel({ id: 103, referenceName: "ModelC-Unmapped" });
+
+    const saveModel = makeUniqueSaveModel();
+    jest.spyOn(stateModule, "getApiClient").mockReturnValue(makeApiClient(saveModel));
+
+    const callOrder = spyOnSourceMappingLookupOrder(ModelMapper);
+
+    const { pushModels } = await import("../model-pusher");
+    // Interleaved input: unmapped, mapped, unmapped, mapped.
+    await pushModels([modelA, sourceB, modelC, sourceD], [targetB, targetD]);
+
+    // The first 4 calls are the partition pass (walks input order); the last 4
+    // are the main categorization loop, which walks the reordered list —
+    // already-mapped models first, then the unmapped ones.
+    expect(callOrder).toHaveLength(8);
+    expect(callOrder.slice(0, 4)).toEqual([101, 102, 103, 104]);
+    expect(callOrder.slice(-4)).toEqual([102, 104, 101, 103]);
+  });
+
+  it("preserves each group's original relative order when multiple models share mapped/unmapped status", async () => {
+    const { ModelMapper } = await import("lib/mappers/model-mapper");
+
+    const seeder = new ModelMapper(state.sourceGuid[0], state.targetGuid[0]);
+    // Intentionally descending / non-sorted IDs so preserved order can't be mistaken for a sort.
+    const mappedSources = [402, 401, 400].map((id) =>
+      makeModel({ id, referenceName: `Mapped-${id}`, lastModifiedDate: new Date(2024, 0, 1).toISOString() })
+    );
+    const mappedTargets = mappedSources.map((s) =>
+      makeModel({ id: s.id * 10, referenceName: s.referenceName, lastModifiedDate: s.lastModifiedDate })
+    );
+    mappedSources.forEach((s, i) => seeder.addMapping(s, mappedTargets[i]));
+
+    const unmappedSources = [301, 305, 309].map((id) => makeModel({ id, referenceName: `Unmapped-${id}` }));
+
+    const sourceData = [
+      unmappedSources[0],
+      mappedSources[0],
+      unmappedSources[1],
+      mappedSources[1],
+      unmappedSources[2],
+      mappedSources[2],
+    ];
+
+    const saveModel = makeUniqueSaveModel();
+    jest.spyOn(stateModule, "getApiClient").mockReturnValue(makeApiClient(saveModel));
+
+    const callOrder = spyOnSourceMappingLookupOrder(ModelMapper);
+
+    const { pushModels } = await import("../model-pusher");
+    await pushModels(sourceData, mappedTargets);
+
+    expect(callOrder.slice(-6)).toEqual([402, 401, 400, 301, 305, 309]);
+  });
+
+  it("leaves processing order unchanged on a clean run with no existing mappings", async () => {
+    const { ModelMapper } = await import("lib/mappers/model-mapper");
+
+    const sourceData = [11, 12, 13, 14].map((id) => makeModel({ id, referenceName: `Clean-${id}` }));
+
+    const saveModel = makeUniqueSaveModel();
+    jest.spyOn(stateModule, "getApiClient").mockReturnValue(makeApiClient(saveModel));
+
+    const callOrder = spyOnSourceMappingLookupOrder(ModelMapper);
+
+    const { pushModels } = await import("../model-pusher");
+    const result = await pushModels(sourceData, []);
+
+    // No existingMappedModels group; ordering and outcome match a plain input-order run.
+    expect(callOrder.slice(-4)).toEqual([11, 12, 13, 14]);
+    expect(result.failed).toBe(0);
+    expect(result.skipped).toBe(0);
+    expect(result.successful).toBe(4);
+  });
+});


### PR DESCRIPTION
## Summary

[PROD-2250](https://agilitycms.atlassian.net/browse/PROD-2250) — add a guard so that during a model push, source models that already have an entry in the mappings file are processed **before** brand-new (unmapped) models.

Reconciling existing target models first — using their known mapping — avoids ordering issues where a net-new model is created ahead of its already-mapped dependencies, and keeps the mappings file consistent.

## Changes

- **`src/lib/pushers/model-pusher.ts`** — before the main categorization loop, partition source models into `existingMappedModels` (where `referenceMapper.getModelMappingByID(id, "source")` is non-null) and `newUnmappedModels`, then iterate `[...existingMappedModels, ...newUnmappedModels]`. Each group preserves its original relative order. The mapper is already loaded, so the membership check is O(1).
- **`src/lib/pushers/tests/model-pusher.test.ts`** — three tests for the new ordering:
  - already-mapped models are processed before brand-new unmapped ones (interleaved input)
  - each group's original relative order is preserved (descending IDs, so it can't be a coincidental sort)
  - a clean run with no existing mappings is unchanged in both order and outcome (regression guard)

## Acceptance criteria

- [x] Push routine first loops through source models that have an existing mapping
- [x] New (unmapped) source models are only processed after all already-mapped models
- [x] Clean-run behaviour/output unchanged (empty `existingMappedModels`)
- [x] Mappings file remains correct after the run

## Testing

- `tsc --noEmit` passes clean.
- Unit tests added (per request, the full suite was not run in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-2250]: https://agilitycms.atlassian.net/browse/PROD-2250?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ