### PR TITLE
PROD-2202: push models first so validation fails before touching target

### DIFF
--- a/src/lib/pushers/orchestrate-pushers.ts
+++ b/src/lib/pushers/orchestrate-pushers.ts
@@ -176,11 +176,18 @@ export class Pushers {
     // Collect individual failure details
     const failureDetails: FailureDetail[] = [];
 
-    // DEPENDENCY-OPTIMIZED ORDER: Galleries → Assets → Models → Containers → Content → Templates → Pages
+    // PROD-2202: Models run FIRST so the model-mapping validation (the rename/reassignment
+    // mismatch detection in pushModels) fails the sync before any galleries or assets are
+    // written to the target. A doomed sync therefore aborts immediately, without touching the
+    // target instance with gallery/asset uploads — failing fast and leaving the target untouched.
+    // Models depend on nothing that follows, so hoisting them ahead of galleries/assets is
+    // dependency-safe; the remaining relative order is unchanged (Containers→Content→Templates→
+    // Pages still follow Models, since each depends on Models being pushed first).
+    // ORDER: Models → Galleries → Assets → Containers → Content → Templates → Pages
     const pusherConfig = [
+      PUSH_OPERATIONS.models,
       PUSH_OPERATIONS.galleries,
       PUSH_OPERATIONS.assets,
-      PUSH_OPERATIONS.models,
       PUSH_OPERATIONS.containers,
       PUSH_OPERATIONS.content,
       PUSH_OPERATIONS.templates,

--- a/src/lib/pushers/tests/orchestrate-pushers.test.ts
+++ b/src/lib/pushers/tests/orchestrate-pushers.test.ts
@@ -259,3 +259,105 @@ describe("Pushers.executePushOperation — callbacks", () => {
     expect(onOperationComplete).toHaveBeenCalledWith("pushModels", "src-u", "tgt-u", true);
   });
 });
+
+// ─── PROD-2202: models pushed first (validation fails fast, before galleries/assets) ─────
+
+describe("Pushers.instanceOrchestrator — models-first ordering (PROD-2202)", () => {
+  // Non-empty data for every element type so every push operation is actually invoked
+  // (executePushOperation skips an op whose dataKey array is empty).
+  function makeEntities(): any {
+    return {
+      pages: [{ pageID: 1 }],
+      templates: [{ pageTemplateID: 1, pageTemplateName: "T" }],
+      containers: [{ contentViewID: 1 }],
+      lists: [],
+      models: [{ id: 1, referenceName: "ModelA" }],
+      content: [{ contentID: 1 }],
+      assets: [{ mediaID: 1 }],
+      galleries: [{ galleryID: 1 }],
+    };
+  }
+
+  // Replace every real pusher handler with a no-op success so no live push runs, and
+  // return the handler-name→spy map so tests can assert which ran (and which did not).
+  async function stubAllHandlers(): Promise<Record<string, jest.SpyInstance>> {
+    const { PUSH_OPERATIONS } = await import("../push-operations-config");
+    const spies: Record<string, jest.SpyInstance> = {};
+    for (const key of Object.keys(PUSH_OPERATIONS)) {
+      spies[PUSH_OPERATIONS[key].name] = jest
+        .spyOn(PUSH_OPERATIONS[key], "handler")
+        .mockResolvedValue({ status: "success", successful: 0, failed: 0, skipped: 0 } as any);
+    }
+    return spies;
+  }
+
+  async function stubDataLoader(): Promise<void> {
+    const { GuidDataLoader } = await import("../guid-data-loader");
+    jest.spyOn(GuidDataLoader.prototype, "loadGuidEntities").mockResolvedValue(makeEntities());
+  }
+
+  it("invokes the models push before galleries and assets", async () => {
+    setState({ sourceGuid: "src-u", targetGuid: "tgt-u", locales: "en-us" });
+    await stubDataLoader();
+    await stubAllHandlers();
+
+    const order: string[] = [];
+    const pushers = new Pushers({
+      onOperationStart: (name) => order.push(name),
+    });
+
+    await pushers.instanceOrchestrator();
+
+    // Models is the very first operation, and precedes both galleries and assets.
+    expect(order[0]).toBe("pushModels");
+    expect(order.indexOf("pushModels")).toBeLessThan(order.indexOf("pushGalleries"));
+    expect(order.indexOf("pushModels")).toBeLessThan(order.indexOf("pushAssets"));
+  });
+
+  it("preserves the downstream relative order after models (Models→Galleries→Assets→Containers→…)", async () => {
+    setState({ sourceGuid: "src-u", targetGuid: "tgt-u", locales: "en-us" });
+    await stubDataLoader();
+    await stubAllHandlers();
+
+    const order: string[] = [];
+    const pushers = new Pushers({ onOperationStart: (name) => order.push(name) });
+
+    await pushers.instanceOrchestrator();
+
+    // Guid-level ops run in this order; content/pages run afterwards in the locale loop.
+    expect(order).toEqual([
+      "pushModels",
+      "pushGalleries",
+      "pushAssets",
+      "pushContainers",
+      "pushTemplates",
+      "pushContent",
+      "pushPages",
+    ]);
+  });
+
+  it("a model-validation failure aborts the sync before galleries or assets are pushed", async () => {
+    setState({ sourceGuid: "src-u", targetGuid: "tgt-u", locales: "en-us" });
+    await stubDataLoader();
+    const spies = await stubAllHandlers();
+
+    // Models validation halts the sync (the rename/reassignment mismatch surfaced by pushModels).
+    spies["pushModels"].mockRejectedValue(new Error("Model validation failed: mapping inconsistency for model"));
+
+    const pushers = new Pushers();
+    const results = await pushers.instanceOrchestrator();
+
+    // The models handler ran and threw; galleries/assets were never reached — the target is untouched.
+    expect(spies["pushModels"]).toHaveBeenCalledTimes(1);
+    expect(spies["pushGalleries"]).not.toHaveBeenCalled();
+    expect(spies["pushAssets"]).not.toHaveBeenCalled();
+
+    // The failure is recorded on the guid orchestration result and carries the validation message.
+    expect(results[0].failed).toEqual([
+      expect.objectContaining({
+        operation: "guid-orchestration",
+        error: expect.stringContaining("Model validation failed"),
+      }),
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary

[PROD-2202](https://agilitycms.atlassian.net/browse/PROD-2202) — move model validation to the first step of a sync so a sync that will halt (e.g. a rename/reassignment mapping mismatch) fails immediately, before any target writes.

Rather than extracting the validation into a separate pass, this reorders the push pipeline so the whole **Models** push runs first. `pushModels` validates every model (the rename/reassignment mapping-mismatch detection) before it writes anything, so running Models first means a doomed sync aborts before any galleries or assets are uploaded — the target instance is left untouched.

## Changes

- **`src/lib/pushers/orchestrate-pushers.ts`** — `PUSH_OPERATIONS.models` moved to the front of `pusherConfig`:

  `Models → Galleries → Assets → Containers → Content → Templates → Pages`

  Models depend on nothing that precedes them, and Containers/Content/Templates/Pages still follow Models, so the reorder is dependency-safe. Order comment updated with the rationale.
- **`src/lib/pushers/tests/orchestrate-pushers.test.ts`** — three orchestrator tests:
  - models push runs before galleries and assets
  - full downstream relative order is preserved
  - a model-validation failure aborts the sync before galleries/assets are pushed (fail-fast)

## Notes

- The ticket also mentions "before any *pull*." The sync pull is **read-only** and is a prerequisite — validation needs the target's current models, which only exist after the pull. The pull never modifies the target, so failing before the *push* satisfies the "don't touch the target until we know it'll succeed" rationale.
- Scope is **models only**, per the ticket wording. The analogous template-mapping validation (`template-pusher.ts`) was intentionally left in place.

## Testing

- `tsc --noEmit` passes clean.
- Orchestrator unit tests added (the full suite was not run in this session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-2202]: https://agilitycms.atlassian.net/browse/PROD-2202?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ