### PR TITLE
PROD-2312: reserve ✗ glyph for real failures, use ○ for benign skips

### DIFF
--- a/src/lib/pushers/container-pusher.ts
+++ b/src/lib/pushers/container-pusher.ts
@@ -88,7 +88,7 @@ export async function pushContainers(
 
         if (!targetContainer) {
           // Container exists and is up to date - skip
-          logger.container.error(
+          logger.container.skipped(
             sourceContainer,
             `target container: ${existingMapping.targetReferenceName} was deleted, skipping!`,
             targetGuid[0]

--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -102,7 +102,7 @@ export async function pushModels(sourceData: mgmtApi.Model[], targetData: mgmtAp
 
   for (const sourceModel of orderedModels) {
     if (!sourceModel.id || !sourceModel.referenceName) {
-      logger.model.error(
+      logger.model.skipped(
         sourceModel,
         "Model is missing required properties (id or referenceName), skipping",
         targetGuid[0]

--- a/src/lib/pushers/page-pusher/process-page.ts
+++ b/src/lib/pushers/page-pusher/process-page.ts
@@ -53,7 +53,7 @@ export async function processPage({
       // Find the template mapping
       let templateRef = templateMapper.getTemplateMappingByPageTemplateName(page.templateName, "source");
       if (!templateRef) {
-        logger.page.error(
+        logger.page.skipped(
           page,
           `Missing page template ${page.templateName} in source data, skipping`,
           locale,


### PR DESCRIPTION
## Root cause

The push/sync per-line log emitted the red ✗ failure glyph for several benign skips, making runs look catastrophically broken. The glyph is chosen by log status in \`src/core/logs.ts\` (\`failed\` → red ✗, \`skipped\` → yellow ○), and the \`.error(...)\` vs \`.skipped(...)\` logger helpers map to those statuses. A handful of skip paths incremented the skip counter (or recorded a preflight \`action: \"skip\"\`) but logged via \`logger.<entity>.error(...)\`, so the per-line glyph disagreed with the actual outcome.

The phase-summary counts were already correct — these paths already did \`skipped++\` / recorded \`action: \"skip\"\`. This change only fixes the per-line glyph; no counts change.

## Call sites changed

- \`src/lib/pushers/container-pusher.ts\` (~line 91): target container was deleted → \`.error\` → \`.skipped\`. Records preflight \`action: \"skip\"\` and does \`skipped++; continue;\`.
- \`src/lib/pushers/model-pusher.ts\` (~line 105): model missing required id/referenceName ("...skipping") → \`.error\` → \`.skipped\`. Does \`skipped++; continue;\`.
- \`src/lib/pushers/page-pusher/process-page.ts\` (~line 56): missing page template in source data ("...skipping") → \`.error\` → \`.skipped\`. Records preflight \`action: \"skip\"\` and returns \`{ status: \"skip\" }\`.

## Left unchanged (genuine failures / conflicts, verified)

Reviewed every \`logger.<entity>.error(...)\` call under \`src/lib/pushers/**\`. All remaining ones are real failures (catch blocks with \`failed++\`, \`throw\`, or \`return { status: \"failure\" }\`), or conflicts recorded as \`action: \"conflict\"\` (e.g. container/gallery/asset "target changed; use --overwrite"). One change-detection catch logs an error but still processes the item, so it is not a skip. These were intentionally not touched.

## Testing

\`npm run type-check\` passes. No new unit test added: the status→glyph mapping is covered by \`src/core/tests/logs.test.ts\` and the skip-count paths by existing pusher tests; reproducing the deleted-target-mapping branch would require non-trivial ContainerMapper filesystem setup for little added coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)