### PR TITLE
PROD-2307: adopt existing target containers by referenceName (mapping self-heal)

### DIFF
--- a/src/lib/pushers/container-pusher.ts
+++ b/src/lib/pushers/container-pusher.ts
@@ -78,6 +78,45 @@ export async function pushContainers(
       // if no mapping found, we should be creating the container
       shouldCreate = existingMapping === null;
 
+      // PROD-2307: before creating, adopt an existing target container that matches by
+      // referenceName but has no mapping row (e.g. a fresh machine / wiped mapping cache,
+      // or a create that succeeded server-side but was never mapped). Container reference
+      // names are unique per instance, so a name match is a safe identity. This mirrors the
+      // model-pusher PROD-2211 map-on-adopt path: without it, a mapping-less run re-creates
+      // containers and drops the mapping row that downstream content/pages rely on.
+      if (shouldCreate) {
+        const targetByRef =
+          targetData?.find(
+            (tc: mgmtApi.Container) =>
+              tc.referenceName?.toLowerCase() === sourceContainer.referenceName?.toLowerCase()
+          ) || null;
+
+        if (targetByRef) {
+          if (targetModelID >= 1 && targetByRef.contentDefinitionID !== targetModelID) {
+            // Pathological: same reference name, different model. Adopt on the (unique) name,
+            // but surface the mismatch so it can be investigated.
+            logger.log(
+              "WARN",
+              `Adopting existing target container "${sourceContainer.referenceName}" by referenceName, ` +
+                `but its model (${targetByRef.contentDefinitionID}) differs from the mapped source model (${targetModelID}).`
+            );
+          }
+
+          if (!state.preflight) {
+            containerMapper.addMapping(sourceContainer, targetByRef);
+          }
+          logger.container.skipped(sourceContainer, "already exists on target; mapping row created", targetGuid[0]);
+          preflightReport.record({
+            phase: "Containers",
+            action: "skip",
+            name: sourceContainer.referenceName,
+            detail: "adopted existing target container (mapping row created)",
+          });
+          skipped++;
+          continue; // finally{} still runs (processedCount++); no create/update this run
+        }
+      }
+
       if (!shouldCreate) {
         // get the target container, check if the source and targets need updates
         const targetContainer: mgmtApi.Container =

--- a/src/lib/pushers/tests/container-pusher.test.ts
+++ b/src/lib/pushers/tests/container-pusher.test.ts
@@ -154,6 +154,85 @@ describe("pushContainers — RichTextArea special case", () => {
   });
 });
 
+// ─── pushContainers — PROD-2307 adopt-by-referenceName ────────────────────────
+
+describe("pushContainers — adopt existing target container by referenceName (PROD-2307)", () => {
+  it("adopts an unmapped target container that matches by referenceName instead of creating", async () => {
+    const saveContainer = jest.fn();
+    state.cachedApiClient = { containerMethods: { saveContainer } } as any;
+
+    const { ContainerMapper } = await import("lib/mappers/container-mapper");
+    const addMappingSpy = jest.spyOn(ContainerMapper.prototype, "addMapping");
+
+    const { pushContainers } = await import("../container-pusher");
+
+    // Source has no mapping row (fresh cache); target already has a same-named container.
+    const source = makeContainer({ referenceName: "AdoptMe", contentDefinitionID: 500 });
+    const target = makeContainer({ referenceName: "AdoptMe", contentDefinitionID: 500 });
+
+    const result = await pushContainers([source], [target]);
+
+    // Adopted, not created.
+    expect(saveContainer).not.toHaveBeenCalled();
+    expect(addMappingSpy).toHaveBeenCalledTimes(1);
+    expect(result.skipped).toBe(1);
+    expect(result.successful).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it("matches referenceName case-insensitively", async () => {
+    const saveContainer = jest.fn();
+    state.cachedApiClient = { containerMethods: { saveContainer } } as any;
+
+    const { pushContainers } = await import("../container-pusher");
+
+    const source = makeContainer({ referenceName: "MixedCase", contentDefinitionID: 500 });
+    const target = makeContainer({ referenceName: "mixedcase", contentDefinitionID: 500 });
+
+    const result = await pushContainers([source], [target]);
+
+    expect(saveContainer).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+
+  it("still creates when no target container matches by referenceName", async () => {
+    const created = makeContainer({ contentViewID: 777, contentDefinitionID: 1 });
+    const saveContainer = jest.fn().mockResolvedValue(created);
+    state.cachedApiClient = { containerMethods: { saveContainer } } as any;
+
+    const { pushContainers } = await import("../container-pusher");
+
+    // contentDefinitionID=1 → RichTextArea special case makes targetModelID valid, so create proceeds.
+    const source = makeContainer({ referenceName: "BrandNew", contentDefinitionID: 1 });
+    const nonMatch = makeContainer({ referenceName: "SomethingElse" });
+
+    const result = await pushContainers([source], [nonMatch]);
+
+    expect(saveContainer).toHaveBeenCalledTimes(1);
+    expect(result.successful).toBe(1);
+  });
+
+  it("does not write a mapping during preflight (dry run), but still records the adopt as a skip", async () => {
+    state.preflight = true;
+    const saveContainer = jest.fn();
+    state.cachedApiClient = { containerMethods: { saveContainer } } as any;
+
+    const { ContainerMapper } = await import("lib/mappers/container-mapper");
+    const addMappingSpy = jest.spyOn(ContainerMapper.prototype, "addMapping");
+
+    const { pushContainers } = await import("../container-pusher");
+
+    const source = makeContainer({ referenceName: "PreflightAdopt", contentDefinitionID: 500 });
+    const target = makeContainer({ referenceName: "PreflightAdopt", contentDefinitionID: 500 });
+
+    const result = await pushContainers([source], [target]);
+
+    expect(saveContainer).not.toHaveBeenCalled();
+    expect(addMappingSpy).not.toHaveBeenCalled();
+    expect(result.skipped).toBe(1);
+  });
+});
+
 // ─── pushContainers — result shape ────────────────────────────────────────────
 
 describe("pushContainers — result shape", () => {


### PR DESCRIPTION
## Summary

Defensive hardening for `container-pusher` — **not** the fix for PROD-2307's headline symptom (see caveats).

When the local mapping cache is absent (fresh machine, CI runner, wiped `agility-files`, or a create that succeeded server-side but was never mapped), `container-pusher` had no fallback: with no mapping row it always took the **create** path. Agility's `saveContainer` dedupes by reference name, so this rarely produced a *visible* duplicate container — but the **missing mapping row is the real damage**. Downstream content/pages resolve container references through `hasValidMappings`, and a missing container mapping tips content into the create path, which is what feeds duplicate accumulation across syncs.

## Change

Mirrors the merged **PROD-2211** map-on-adopt path in `model-pusher`: before creating, look for an existing target container matching by `referenceName` (unique per instance); if found, write the mapping row and **skip** instead of creating.

- Case-insensitive reference-name match
- Mapping write skipped under `--preflight`
- Same-name / different-model match logs a warning (adopts on the unique name)

## What this does NOT do (scope)

- **Does not** resolve the ticket's divergent-hash nested-container doubling (orphans with names the source never had). That needs the source/target nested-container names to **diverge**, a path not reproducible on the current build — likely a ~13.16-era artifact. Cleanup of existing orphans is **PROD-2282**.
- The **content-item duplication** observed under a missing mapping cache is a distinct root cause, tracked separately.

## Testing

- New `container-pusher` unit tests: adopt-by-referenceName, case-insensitive match, still-creates-when-no-match, preflight-no-write.
- Full suite green: **1732 tests / 98 suites**.
- Live verification against test instances (`d46a3d59-u` → `db707fc0-u`): a fresh-state sync now reports containers **adopted (skipped)** with mapping rows written instead of re-created; a second sync is stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)