### PR TITLE
PROD-2230: scope --contentIDs/--pageIDs to the workflows command

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,7 +6,7 @@
 // Core authentication and state management
 export { Auth } from "./auth";
 export { state, setState, resetState, primeFromEnv, getState, getUIMode } from "./state";
-export { systemArgs, type SystemArgsType } from "./system-args";
+export { systemArgs, workflowArgs, type SystemArgsType } from "./system-args";
 export { normalizeProcessArgs, normalizeArgv } from "./arg-normalizer";
 
 // Main operation services

--- a/src/core/system-args.ts
+++ b/src/core/system-args.ts
@@ -88,24 +88,6 @@ export const systemArgs = {
     default: false,
   },
 
-  // **Explicit ID Override for Workflow Operations**
-  contentIDs: {
-    describe:
-      "Comma-separated list of target content IDs to process. Bypasses mappings lookup when provided (e.g., --contentIDs=121,1221,345).",
-    demandOption: false,
-    alias: ["content-ids", "contentIds", "ContentIDs", "CONTENTIDS"],
-    type: "string" as const,
-    default: "",
-  },
-  pageIDs: {
-    describe:
-      "Comma-separated list of target page IDs to process. Bypasses mappings lookup when provided (e.g., --pageIDs=12,11,45).",
-    demandOption: false,
-    alias: ["page-ids", "pageIds", "PageIDs", "PAGEIDS"],
-    type: "string" as const,
-    default: "",
-  },
-
   // Instance identification args
   sourceGuid: {
     describe:
@@ -146,6 +128,34 @@ export const systemArgs = {
       if (["content", "pages", "both"].includes(lower)) return lower;
       return "both"; // Default to 'both' for any other value
     },
+  },
+};
+
+/**
+ * Args exclusive to the `workflows` command (PROD-2230).
+ *
+ * These bypass the mappings lookup for workflow operations (publish/unpublish/
+ * approve/decline). They must NOT be spread into pull/push/sync's builders —
+ * those commands never read state.explicitContentIDs/explicitPageIDs (only
+ * lib/workflows/workflow-operation.ts does), so showing them there previously
+ * advertised a filter that silently did nothing.
+ */
+export const workflowArgs = {
+  contentIDs: {
+    describe:
+      "Comma-separated list of target content IDs to process. Bypasses mappings lookup when provided (e.g., --contentIDs=121,1221,345).",
+    demandOption: false,
+    alias: ["content-ids", "contentIds", "ContentIDs", "CONTENTIDS"],
+    type: "string" as const,
+    default: "",
+  },
+  pageIDs: {
+    describe:
+      "Comma-separated list of target page IDs to process. Bypasses mappings lookup when provided (e.g., --pageIDs=12,11,45).",
+    demandOption: false,
+    alias: ["page-ids", "pageIds", "PageIDs", "PAGEIDS"],
+    type: "string" as const,
+    default: "",
   },
 };
 

--- a/src/core/tests/system-args.test.ts
+++ b/src/core/tests/system-args.test.ts
@@ -1,4 +1,4 @@
-import { systemArgs } from "../system-args";
+import { systemArgs, workflowArgs } from "../system-args";
 
 // ─── Structure ─────────────────────────────────────────────────────────────────
 
@@ -13,8 +13,6 @@ describe("systemArgs – required keys exist", () => {
     "elements",
     "models",
     "modelsWithDeps",
-    "contentIDs",
-    "pageIDs",
     "sourceGuid",
     "targetGuid",
     "overwrite",
@@ -41,10 +39,31 @@ describe("systemArgs – removed keys do not exist", () => {
     "force",
     "update",
     "reset",
+    // PROD-2230: contentIDs/pageIDs only have an effect for `workflows` (which
+    // reads state.explicitContentIDs/explicitPageIDs) — pull/push/sync never
+    // consumed them, so showing them in those commands' --help was misleading.
+    // They now live in workflowArgs, scoped to the `workflows` builder only.
+    "contentIDs",
+    "pageIDs",
   ];
 
   it.each(removedKeys)('no longer exposes "%s"', (key) => {
     expect(systemArgs).not.toHaveProperty(key);
+  });
+});
+
+describe("workflowArgs – contentIDs/pageIDs scoped to `workflows` only (PROD-2230)", () => {
+  it.each(["contentIDs", "pageIDs"])('has key "%s"', (key) => {
+    expect(workflowArgs).toHaveProperty(key);
+  });
+
+  it.each(["contentIDs", "pageIDs"])('"%s" declares type "string"', (key) => {
+    expect((workflowArgs as any)[key].type).toBe("string");
+  });
+
+  it.each(["contentIDs", "pageIDs"])('"%s" has a non-empty describe (shown in --help)', (key) => {
+    expect(typeof (workflowArgs as any)[key].describe).toBe("string");
+    expect((workflowArgs as any)[key].describe.length).toBeGreaterThan(0);
   });
 });
 
@@ -64,8 +83,6 @@ describe("systemArgs – types", () => {
       "elements",
       "models",
       "modelsWithDeps",
-      "contentIDs",
-      "pageIDs",
       "sourceGuid",
       "targetGuid",
     ];

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
   resetState,
   primeFromEnv,
   systemArgs,
+  workflowArgs,
   normalizeProcessArgs,
   normalizeArgv,
 } from "./core";
@@ -290,6 +291,8 @@ yargs.command({
     },
     // System args (commonly repeated across commands)
     ...systemArgs,
+    // Explicit content/page ID overrides — only meaningful for workflow operations (PROD-2230)
+    ...workflowArgs,
   },
   handler: async function (argv) {
     resetState(); // Clear any previous command state


### PR DESCRIPTION
## Summary
- `pull`/`push`/`sync --help` advertised `--contentIDs` and `--pageIDs`, but those commands never consumed them — only `lib/workflows/workflow-operation.ts` reads `state.explicitContentIDs`/`state.explicitPageIDs`. Passing them to a real sync silently did nothing, which is exactly what [PROD-2230](https://agilitycms.atlassian.net/browse/PROD-2230) reported (the ticket's Done status was based on `--dryRun` being removed; `--contentIDs`/`--pageIDs` were left behind).
- Moved `contentIDs`/`pageIDs` out of the shared `systemArgs` object into a new `workflowArgs` object, spread only into the `workflows` command builder — the same scoping pattern already used to remove `--dryRun` from `pull`/`push`/`sync`.
- No behavior change for `workflows` itself.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 105/105 suites, 1897/1897 tests passing (6 new tests added covering the new scoping; updated the tests that asserted the old shape)
- [x] `node dist/index.js push --help` / `sync --help` / `pull --help` no longer mention `--contentIDs`/`--pageIDs`
- [x] `node dist/index.js workflows --help` still shows both, unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-2230]: https://agilitycms.atlassian.net/browse/PROD-2230?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ