### PR TITLE
PROD-2315: fix "type 0" wording leak in cross-kind model collision message

### DIFF
--- a/src/lib/pushers/model-pusher.ts
+++ b/src/lib/pushers/model-pusher.ts
@@ -20,10 +20,19 @@ function modelTypeMatches(a: mgmtApi.Model, b: mgmtApi.Model): boolean {
   return aType === bType;
 }
 
-/** Human-readable model kind for messages. 1 = content, 2 = component/module. */
+/**
+ * Human-readable model kind for messages.
+ *
+ * PROD-2315: per the SDK's ContentDefinitionTypeID enum, 0 = List (a content model backing a
+ * container/content list — the common case) and 1 = SingleItem (a content model for a single
+ * item) are BOTH content models; only 2 = Component (module/component) is the other kind. This
+ * previously only recognized 1 as "content" and let 0 fall through to the internal `"type 0"`
+ * label — which fired on most real collisions, since list-backed content models (0) are far more
+ * common than single-item ones (1).
+ */
 function modelKindName(model: mgmtApi.Model): string {
   const t = (model as any)?.contentDefinitionTypeID;
-  return t === 1 ? "content" : t === 2 ? "component/module" : `type ${t}`;
+  return t === 0 || t === 1 ? "content" : t === 2 ? "component/module" : `type ${t}`;
 }
 
 /**

--- a/src/lib/pushers/tests/model-pusher.test.ts
+++ b/src/lib/pushers/tests/model-pusher.test.ts
@@ -592,6 +592,24 @@ describe("pushModels — cross-kind reference-name collision (PROD-2315)", () =>
     expect(result.failureDetails![0].error).toMatch(/content model with that reference name already exists/);
   });
 
+  it("labels a List-type (contentDefinitionTypeID 0) collision as \"content\", not \"type 0\" (PROD-2315 wording)", async () => {
+    const saveModel = jest.fn();
+    jest.spyOn(stateModule, "getApiClient").mockReturnValue(makeApiClient(saveModel));
+
+    const { pushModels } = await import("../model-pusher");
+
+    // Source LinkCard is a List-backed content model (type 0) — the common case for real
+    // container-backed models — colliding with a component (type 2) on the target.
+    const sourceModel = makeModel({ referenceName: "LinkCard", contentDefinitionTypeID: 0 });
+    const targetModel = makeModel({ id: 504, referenceName: "LinkCard", contentDefinitionTypeID: 2 });
+
+    const result = await pushModels([sourceModel], [targetModel]);
+
+    expect(result.failureDetails).toHaveLength(1);
+    expect(result.failureDetails![0].error).toMatch(/is a content model on the source/);
+    expect(result.failureDetails![0].error).not.toMatch(/type 0/);
+  });
+
   it("does NOT flag a same-name model when the kinds are unknown (falls back to adopt-by-reference)", async () => {
     const saveModel = jest.fn();
     jest.spyOn(stateModule, "getApiClient").mockReturnValue(makeApiClient(saveModel));


### PR DESCRIPTION
## Summary
- [PROD-2315](https://agilitycms.atlassian.net/browse/PROD-2315) is marked Done, but the collision message still leaked internal jargon: `modelKindName()` in `src/lib/pushers/model-pusher.ts` only mapped `contentDefinitionTypeID === 1` (SDK enum `SingleItem`) to `"content"`, so `0` (`List` — the type most real container-backed content models actually have) fell through to the generic `` `type ${t}` `` label.
- This wasn't a rare edge case: in the 2026-07-29 validation sweep, 6 of 7 real collision fixtures rendered as `"is a type 0 model"`; only the one fixture that happened to be `SingleItem`-typed rendered correctly as `"content"`.
- Fix: treat both `0` (List) and `1` (SingleItem) as `"content"` — both are content models, only `2` (Component) is the other kind.
- Added a regression test using `contentDefinitionTypeID: 0` — the existing PROD-2315 tests only ever used `1` for the content side, which is exactly why this slipped through unnoticed.

No behavior change to collision *detection* — only the failure message wording. The soft-fail/continue behavior (collision is recorded in `failureDetails` and the sync continues, per PROD-2310's "count and report, don't abort" design) is unchanged.

## Test plan
- [x] `npx tsc --noEmit` clean
- [x] `npx jest` — 105/105 suites, 1892/1892 tests passing (1 new regression test added)
- [x] Live-verified against `832a35c9-u` → `2e57774f-u`'s real collision fixtures: all 7 now say `"is a content model"` / `"content model with that reference name"`, zero `"type 0"` occurrences

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[PROD-2315]: https://agilitycms.atlassian.net/browse/PROD-2315?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ